### PR TITLE
Extend OcTree model import/export

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ notifications:
   email: false
 
 before_install:
-  - julia -e 'Pkg.clone("https://github.com/JuliaInv/jInv.jl","jInv"); Pkg.build("jInv");
+  - julia -e 'Pkg.clone("https://github.com/JuliaInv/jInv.jl","jInv"); Pkg.build("jInv");'
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,23 @@
 # Documentation: http://docs.travis-ci.com/user/languages/julia/
+
 language: julia
+
 os:
   - linux
   - osx
+
 julia:
-  - release
-  - nightly
+  - 0.5
+
 notifications:
   email: false
-# uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("JOcTree"); Pkg.test("JOcTree"; coverage=true)'
+
+before_install:
+  - julia -e 'Pkg.clone("https://github.com/JuliaInv/jInv.jl","jInv"); Pkg.build("jInv");
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+
+script:
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("JOcTree"); Pkg.test("JOcTree"; coverage=true)'
+
+after_success:
+  - julia -e 'cd(Pkg.dir("JOcTree")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ install:
         "C:\projects\julia-binary.exe")
 # Run installer silently, output to C:\projects\julia
   - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - C:\projects\julia\bin\julia -e "versioninfo(); Pkg.init(); Pkg.clone(\"https://github.com/JuliaInv/jInv.jl\"),Pkg.build(\"jInv\");"
 
 build_script:
 # Need to convert from shallow to complete for Pkg.clone to work

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,10 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win64.exe"
 
 branches:
   only:
     - master
-    - /release-.*/
 
 notifications:
   - provider: Email

--- a/src/IO/exportUBC.jl
+++ b/src/IO/exportUBC.jl
@@ -1,5 +1,5 @@
 
-export exportUBCOcTreeMesh, exportUBCOcTreeModel, outputOctreeMesh
+export exportUBCOcTreeMesh, exportUBCOcTreeModel
 
 
 """
@@ -36,7 +36,7 @@ function exportUBCOcTreeMesh(fname::AbstractString, mesh::OcTreeMesh)
     println(f, n, " ! size of octree mesh")
     for i = 1:n
         idx = p[i]
-        @printf(f,"%i %i %i %i\n", i1[idx], i2[idx], i3[idx], bsz[idx])
+        println(f, i1[idx], " ", i2[idx], " ", i3[idx], " ", bsz[idx])
     end
     close(f)
     return
@@ -51,10 +51,10 @@ end
     
         name::AbstractString - File to write
         mesh::OcTreeMesh     - The mesh corresponding to the model
-        model::Union{Array{Float64,1}, Array{Int64,1}} - The model 
+        model::Array{T,N}    - The model (N = 1,2)
             
 """
-function exportUBCOcTreeModel(name::AbstractString, mesh::OcTreeMesh, model::Union{Array{Float64,1}, Array{Int64,1}})
+function exportUBCOcTreeModel{T}(name::AbstractString, mesh::OcTreeMesh, model::Array{T,1})
 
     m1,m2,m3     = mesh.n
     i1,i2,i3,bsz = find3(mesh.S)
@@ -65,12 +65,37 @@ function exportUBCOcTreeModel(name::AbstractString, mesh::OcTreeMesh, model::Uni
     n = nnz(mesh.S)
     S = sub2ind( (m1,m2,m3), i1,i2,i3 )
     p = sortpermFast(S)[1]
-    modelPerm = model[p]
 
     # Write model vector
     f = open(name, "w")
     for i = 1:n
-        println(f, modelPerm[i])
+        idx = p[i]
+        println(f, model[idx])
+    end
+    close(f)
+    return
+end
+
+function exportUBCOcTreeModel{T}(name::AbstractString, mesh::OcTreeMesh, model::Array{T,2})
+
+    m1,m2,m3     = mesh.n
+    i1,i2,i3,bsz = find3(mesh.S)
+
+    # Roman's code starts the OcTree at the top corner. Change from bottom
+    # corner.
+    i3 = m3 + 2 .- i3 - bsz
+    n = nnz(mesh.S)
+    S = sub2ind( (m1,m2,m3), i1,i2,i3 )
+    p = sortpermFast(S)[1]
+    
+    ncol = size(model,2)
+
+    # Write model vector
+    f = open(name, "w")
+    for i = 1:n
+        idx = p[i]
+        line = join(ASCIIString[ string(model[idx,j]) for j = 1:ncol ], " ")
+        println(f, line)
     end
     close(f)
     return

--- a/src/IO/exportUBC.jl
+++ b/src/IO/exportUBC.jl
@@ -94,7 +94,7 @@ function exportUBCOcTreeModel{T}(name::AbstractString, mesh::OcTreeMesh, model::
     f = open(name, "w")
     for i = 1:n
         idx = p[i]
-        line = join(ASCIIString[ string(model[idx,j]) for j = 1:ncol ], " ")
+        line = join(String[ string(model[idx,j]) for j = 1:ncol ], " ")
         println(f, line)
     end
     close(f)

--- a/src/IO/importUBC.jl
+++ b/src/IO/importUBC.jl
@@ -136,18 +136,14 @@ function importUBCOcTreeModel(modelfile::AbstractString, mesh::OcTreeMesh, T::Da
   	# convert to numbers
     if ncol == 1
         model = Array{T}(n)
-        for i = 1:n
-            idx = p[i]
-            model[idx] = parse(T,s[i])
-        end
     else
         model = Array{T}(n,ncol)
-        for i = 1:n
-            idx = p[i]
-            d = split(s[i])
-            for j = 1:ncol
-                model[idx,j] = parse(T,d[j])
-            end
+    end
+    for i = 1:n
+        idx = p[i]
+        d = split(s[i])
+        for j = 1:ncol
+            model[idx,j] = parse(T,d[j])
         end
     end
 

--- a/src/IO/importUBC.jl
+++ b/src/IO/importUBC.jl
@@ -89,7 +89,7 @@ function importUBCOcTreeMesh(meshfile::AbstractString)
 end
 
 """
-    model = importUBCOcTreeMesh(modelfile, mesh)
+    model = importUBCOcTreeModel(modelfile, mesh, DataType=Float64)
     
     Reads an OcTree model in UBC format from disk.
 
@@ -97,16 +97,18 @@ end
     
         modelfile::AbstractString - File to read
         mesh::OcTreeMeshFV        - The corresponding mesh
+        T::DataType               - Data type of model (Float64, Int64, Bool, ...)
 
     Output:
 
         model::Array{Float64,1} - The model
+        model::Array{Float64,2}
             
 """
-function importUBCOcTreeModel(modelfile::AbstractString, mesh::OcTreeMesh)
+function importUBCOcTreeModel(modelfile::AbstractString, mesh::OcTreeMesh, T::DataType=Float64)
 
     # open file (throws error if file doesn't exist)
-    f    = open(modelfile,"r")
+    f = open(modelfile,"r")
 
     # read everything
     s = readlines(f)
@@ -114,14 +116,9 @@ function importUBCOcTreeModel(modelfile::AbstractString, mesh::OcTreeMesh)
     # close
     close(f)
 
-    # convert to numbers
-    model = Array{Float64}(length(s))
-    for i = 1:length(s)
-        model[i] = parse(Float64,s[i])
-    end
-
     # check if we have the correct number of cell values
-    if length(model) != mesh.nc
+    n = mesh.nc
+    if length(s) != n
         error("Incorrect number of cell values")
     end
 
@@ -129,12 +126,30 @@ function importUBCOcTreeModel(modelfile::AbstractString, mesh::OcTreeMesh)
     m1,m2,m3 = mesh.n
     i1,i2,i3,bsz = find3(mesh.S)
     i3 = m3 + 2 .- i3 - bsz
-
-    n = nnz(mesh.S)
-
     S = sub2ind( (m1,m2,m3), i1,i2,i3 )
     p = sortpermFast(S)[1]
-    ipermute!(model,p)
+	
+    # check for multiple values per cell
+  	d = split(s[1])
+  	ncol = length(d)
+	
+  	# convert to numbers
+    if ncol == 1
+        model = Array{T}(n)
+        for i = 1:n
+            idx = p[i]
+            model[idx] = parse(T,s[i])
+        end
+    else
+        model = Array{T}(n,ncol)
+        for i = 1:n
+            idx = p[i]
+            d = split(s[i])
+            for j = 1:ncol
+                model[idx,j] = parse(T,d[j])
+            end
+        end
+    end
 
     return model
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,9 @@
-
 using JOcTree
 using Base.Test
 
+include("randomOctreeMesh.jl") 
+
 @testset "JOcTree" begin
-println("==== test input & output ====")
 include("testIO.jl")
 include("testMatrices.jl")
 include("testMassMatrixDerivatives.jl")

--- a/test/testIO.jl
+++ b/test/testIO.jl
@@ -1,9 +1,15 @@
+println("Testing: exportUBCOcTreeMesh, importUBCOcTreeMesh, exportUBCOcTreeModel, importUBCOcTreeModel")
+
 @testset "IO" begin
-include("randomOctreeMesh.jl") 
-S = randomOctreeMesh( [256, 256, 256], 5 )
 
+n = [128, 128, 128]
+h = rand(1.:100.0,3)   # cell size
+x0 = rand(1.:100.0,3)
 
-meshOut = getOcTreeMeshFV(S, rand(1.:100.0,3); x0=rand(1.:100.0,3))
+nrand = 5
+S = randomOctreeMesh(n, nrand)
+
+meshOut = getOcTreeMeshFV(S, h; x0=x0)
 exportUBCOcTreeMesh("mesh.msh", meshOut)
 meshIn = importUBCOcTreeMesh("mesh.msh")
 @test meshIn==meshOut

--- a/test/testIO.jl
+++ b/test/testIO.jl
@@ -4,16 +4,34 @@ S = randomOctreeMesh( [256, 256, 256], 5 )
 
 
 meshOut = getOcTreeMeshFV(S, rand(1.:100.0,3); x0=rand(1.:100.0,3))
-modelOut = rand(1:0.1:100, meshOut.nc)
 exportUBCOcTreeMesh("mesh.msh", meshOut)
-exportUBCOcTreeModel("model.mod", meshOut, modelOut)
-
 meshIn = importUBCOcTreeMesh("mesh.msh")
-modelIn = importUBCOcTreeModel("model.mod", meshIn);
-
 @test meshIn==meshOut
-@test modelIn==modelOut
+
+for modelOut in [
+    rand(1:0.1:100, meshOut.nc),
+    rand(1:0.1:100, meshOut.nc,3)]
+    
+    exportUBCOcTreeModel("model.mod", meshOut, modelOut)
+    modelIn = importUBCOcTreeModel("model.mod", meshIn)
+    @test modelIn==modelOut  
+    
+end
+
+for modelOut in [
+    rand(1:100, meshOut.nc),
+    rand(1:100, meshOut.nc,3),
+    rand(1:0.1:100, meshOut.nc),
+    rand(1:0.1:100, meshOut.nc,3)]
+    
+    exportUBCOcTreeModel("model.mod", meshOut, modelOut)
+    modelIn = importUBCOcTreeModel("model.mod", meshIn, eltype(modelOut))
+    @test modelIn==modelOut
+    @test eltype(modelIn)==eltype(modelOut)
+    
+end
 
 rm("mesh.msh")
 rm("model.mod")
+
 end

--- a/test/testIO.jl
+++ b/test/testIO.jl
@@ -10,7 +10,8 @@ meshIn = importUBCOcTreeMesh("mesh.msh")
 
 for modelOut in [
     rand(1:0.1:100, meshOut.nc),
-    rand(1:0.1:100, meshOut.nc,3)]
+    rand(1:0.1:100, meshOut.nc,3),
+    rand(1:0.1:100, meshOut.nc,6)]
     
     exportUBCOcTreeModel("model.mod", meshOut, modelOut)
     modelIn = importUBCOcTreeModel("model.mod", meshIn)
@@ -19,10 +20,12 @@ for modelOut in [
 end
 
 for modelOut in [
+    rand(Bool, meshOut.nc),
+    rand(Bool, meshOut.nc, 3),
     rand(1:100, meshOut.nc),
-    rand(1:100, meshOut.nc,3),
+    rand(1:100, meshOut.nc, 3),
     rand(1:0.1:100, meshOut.nc),
-    rand(1:0.1:100, meshOut.nc,3)]
+    rand(1:0.1:100, meshOut.nc, 3)]
     
     exportUBCOcTreeModel("model.mod", meshOut, modelOut)
     modelIn = importUBCOcTreeModel("model.mod", meshIn, eltype(modelOut))

--- a/test/testMatrices.jl
+++ b/test/testMatrices.jl
@@ -3,8 +3,6 @@ using JOcTree
 using Base.Test
 
 include("getFunction.jl")
-include("randomOctreeMesh.jl") 
-
 
 # Test the following matrices:
 #   getNodalGradientMatrix, getCurlMatrix, getDivergenceMatrix
@@ -17,7 +15,7 @@ println("Testing: getNodalGradientMatrix, getCurlMatrix, getDivergenceMatrix")
 
 #-------------------------------------------
 
-n = [128 , 128 , 128]   # underlying mesh
+n = [64, 64, 32]   # underlying mesh
 h = 1 ./ n   # cell size
 x0 = [0. , 0. , 0.]
 
@@ -26,7 +24,7 @@ S = randomOctreeMesh( n, nrand )
 
 M = getOcTreeMeshFV(S, h, x0=x0)
 
-exportUBCOcTreeMesh("mesh.txt", M)
+# exportUBCOcTreeMesh("mesh.txt", M)
 
 #-------------------------------------------
 
@@ -52,7 +50,7 @@ println("nnz(CURLGRAD)  ", nnz(CURLGRAD))
 
 xyz = getCellCenteredGrid(M)
 f = getF( xyz[:,1], xyz[:,2], xyz[:,3] )
-exportUBCOcTreeModel("model.txt", M,f)
+# exportUBCOcTreeModel("model.txt", M,f)
 
 
 println()
@@ -142,6 +140,7 @@ for i = 1:ntests
 
 end  # i
 
+println()
 
 # Make sure that the inf norm decreases as the number cells increase.
 


### PR DESCRIPTION
     - Extend OcTree model export/import to support multiple values per
       cell such as the three or six components of a diagonal or
       symmetric tensor
    
     - Generalize element type of model array from union of two
       specific types Float64 and Int64 to generic type T
    
     - Remove explicit permutation of model arrays and replace by
       reading/writing in place

     - Cleanup
