### PR TITLE
Parametrize OcTreeMeshFV and SparseArray3D

### DIFF
--- a/src/IO/HDF5.jl
+++ b/src/IO/HDF5.jl
@@ -5,7 +5,7 @@ export exportHDF5OcTreeMesh, importHDF5OcTreeMesh
     exportHDF5OcTreeMesh(filename::String, meshes::Vector{T} where T<:OcTreeMesh; <keyword arguments>)
     exportHDF5OcTreeMesh(filename::String, meshes::Dict; <keyword arguments>)
     exportHDF5OcTreeMesh(filename::String, S::SparseArray3D, h::Vector{Float64}, x0::Vector{Float64}; <keyword arguments>)
-    
+
 Write OcTree mesh(es) to HDF5 file.
 
 `exportHDF5OcTreeMesh(filename::String, meshes::Vector)` labels the meshes with indices
@@ -104,7 +104,7 @@ end
     importHDF5OcTreeMesh(filename::String, id::String)
     importHDF5OcTreeMesh(filename::String, idList::Vector{N} where N<:Integer)
     importHDF5OcTreeMesh(filename::String, idList::Vector{String})
-    
+
 Import OcTree mesh(es) from HDF5 file.
 
 `importHDF5OcTreeMesh(filename)` returns the OcTree mesh if the file contains a single
@@ -130,7 +130,7 @@ function importHDF5OcTreeMesh(filename::String)
             svi = read(gmesh["sparse3/i"])
             bsz = read(gmesh["sparse3/bsz"])
             SV = sparsevec(svi,bsz,prod(n))
-            S = SparseArray3D(SV,n)
+            S = SparseArray3D(SV,(n[1],n[2],n[3]))
             meshes[id] = getOcTreeMeshFV(S,h;x0=x0)
         else
             warn("Found non-mesh object in input file")
@@ -163,7 +163,7 @@ function importHDF5OcTreeMesh(filename::String, id::String)
         svi = read(gmesh["sparse3/i"])
         bsz = read(gmesh["sparse3/bsz"])
         SV = sparsevec(svi,bsz,prod(n))
-        S = SparseArray3D(SV,n)
+        S = SparseArray3D(SV,(n[1],n[2],n[3]))
         mesh = getOcTreeMeshFV(S,h;x0=x0)
     else
         warn("Found non-mesh object in input file")
@@ -197,7 +197,7 @@ function importHDF5OcTreeMesh(filename::String, idList::Vector{String})
             svi = read(gmesh["sparse3/i"])
             bsz = read(gmesh["sparse3/bsz"])
             SV = sparsevec(svi,bsz,prod(n))
-            S = SparseArray3D(SV,n)
+            S = SparseArray3D(SV,(n[1],n[2],n[3]))
             meshes[id] = getOcTreeMeshFV(S,h;x0=x0)
         else
             warn("Found non-mesh object in input file")

--- a/src/IO/exportUBC.jl
+++ b/src/IO/exportUBC.jl
@@ -28,7 +28,8 @@ function exportUBCOcTreeMesh(fname::AbstractString, S::SparseArray3D, h::Vector{
 
     # Roman's code starts the OcTree at the top corner. Change from bottom
     # corner.
-    i3 = m3 + 2 .- i3 - bsz
+    Tn2 = eltype(i3)
+    i3 = m3 + Tn2(2) .- i3 - convert(Vector{Tn2},bsz)
     x3 = x3 + m3 * h3
     S = sub2ind( (m1,m2,m3), i1,i2,i3 )
     p = sortpermFast(S)[1]
@@ -71,7 +72,8 @@ function exportUBCOcTreeModel{T}(name::AbstractString, S::SparseArray3D, model::
 
     # Roman's code starts the OcTree at the top corner. Change from bottom
     # corner.
-    i3 = m3 + 2 .- i3 - bsz
+    Tn2 = eltype(i3)
+    i3 = m3 + Tn2(2) .- i3 - convert(Vector{Tn2},bsz)
     n = nnz(S)
     S = sub2ind( (m1,m2,m3), i1,i2,i3 )
     p = sortpermFast(S)[1]
@@ -95,11 +97,12 @@ function exportUBCOcTreeModel{T}(name::AbstractString, S::SparseArray3D, model::
 
     # Roman's code starts the OcTree at the top corner. Change from bottom
     # corner.
-    i3 = m3 + 2 .- i3 - bsz
+    Tn2 = eltype(i3)
+    i3 = m3 + Tn2(2) .- i3 - convert(Vector{Tn2},bsz)
     n = nnz(S)
     S = sub2ind( (m1,m2,m3), i1,i2,i3 )
     p = sortpermFast(S)[1]
-    
+
     ncol = size(model,2)
 
     # Write model vector

--- a/src/IO/importUBC.jl
+++ b/src/IO/importUBC.jl
@@ -2,28 +2,28 @@ export importUBCOcTreeMesh, importUBCOcTreeModel
 
 """
     mesh = importUBCOcTreeMesh(meshfile)
-    
+
     Reads an OcTree mesh in UBC format from disk.
 
     Input:
-    
+
         meshfile::AbstractString - File to read
 
     Output:
 
         mesh::OcTreeMesh - The mesh
-            
+
 """
-function importUBCOcTreeMesh(meshfile::AbstractString)
+function importUBCOcTreeMesh(meshfile::AbstractString;Tn::Type{N}=Int32,Tn2::Type{N2}=Int64) where N <: Integer where N2 <: Integer
 
     # open file (throws error if file doesn't exist)
     f    = open(meshfile,"r")
 
     # number of cells of underlying tensor mesh along dimension 1, 2, 3
     line = split(readline(f))
-    m1 = parse(Int64,line[1])
-    m2 = parse(Int64,line[2])
-    m3 = parse(Int64,line[3])
+    m1 = parse(Tn2,line[1])
+    m2 = parse(Tn2,line[2])
+    m3 = parse(Tn2,line[3])
 
     # top corner coordinates
     line = split(readline(f))
@@ -39,7 +39,7 @@ function importUBCOcTreeMesh(meshfile::AbstractString)
 
     # number of OcTree cells
     line = split(readline(f))
-    n = parse(Int64,line[1])
+    n = parse(Tn,line[1])
 
     # read rest of file at ones
     lines = readlines(f)
@@ -53,19 +53,19 @@ function importUBCOcTreeMesh(meshfile::AbstractString)
     end
 
     # allocate space
-    i1  = zeros(Int64, n)
-    i2  = zeros(Int64, n)
-    i3  = zeros(Int64, n)
-    bsz = zeros(Int64, n)
+    i1  = zeros(Tn2, n)
+    i2  = zeros(Tn2, n)
+    i3  = zeros(Tn2, n)
+    bsz = zeros(Tn , n)
 
     # convert string array to numbers
     for i = 1:n
         line   = split(lines[i])
 
-        i1[i]  = parse(Int64,line[1])
-        i2[i]  = parse(Int64,line[2])
-        i3[i]  = parse(Int64,line[3])
-        bsz[i] = parse(Int64,line[4])
+        i1[i]  = parse(Tn2,line[1])
+        i2[i]  = parse(Tn2,line[2])
+        i3[i]  = parse(Tn2,line[3])
+        bsz[i] = parse(Tn ,line[4])
     end
 
     # Roman's code starts the OcTree at the top corner. Change to bottom
@@ -90,11 +90,11 @@ end
 
 """
     model = importUBCOcTreeModel(modelfile, mesh, DataType=Float64)
-    
+
     Reads an OcTree model in UBC format from disk.
 
     Input:
-    
+
         modelfile::AbstractString - File to read
         mesh::OcTreeMeshFV        - The corresponding mesh
         T::DataType               - Data type of model (Float64, Int64, Bool, ...)
@@ -103,7 +103,7 @@ end
 
         model::Array{Float64,1} - The model
         model::Array{Float64,2}
-            
+
 """
 function importUBCOcTreeModel(modelfile::AbstractString, mesh::OcTreeMesh, T::DataType=Float64)
 
@@ -128,11 +128,11 @@ function importUBCOcTreeModel(modelfile::AbstractString, mesh::OcTreeMesh, T::Da
     i3 = m3 + 2 .- i3 - bsz
     S = sub2ind( (m1,m2,m3), i1,i2,i3 )
     p = sortpermFast(S)[1]
-	
+
     # check for multiple values per cell
   	d = split(s[1])
   	ncol = length(d)
-	
+
   	# convert to numbers
     if ncol == 1
         model = Array{T}(n)

--- a/src/IO/importUBC.jl
+++ b/src/IO/importUBC.jl
@@ -14,7 +14,7 @@ export importUBCOcTreeMesh, importUBCOcTreeModel
         mesh::OcTreeMesh - The mesh
 
 """
-function importUBCOcTreeMesh(meshfile::AbstractString;Tn::Type{N}=Int32,Tn2::Type{N2}=Int64) where N <: Integer where N2 <: Integer
+function importUBCOcTreeMesh(meshfile::AbstractString;Tn::Type{N}=Int64,Tn2::Type{N2}=Int64) where N <: Integer where N2 <: Integer
 
     # open file (throws error if file doesn't exist)
     f    = open(meshfile,"r")

--- a/src/IO/importUBC.jl
+++ b/src/IO/importUBC.jl
@@ -83,7 +83,7 @@ function importUBCOcTreeMesh(meshfile::AbstractString;Tn::Type{N}=Int64,Tn2::Typ
     bsz = bsz[p] #S[:,4]
 
     # create mesh object
-    S = sparse3(i1,i2,i3,bsz,[m1,m2,m3])
+    S = sparse3(i1,i2,i3,bsz,(m1,m2,m3))
     mesh = getOcTreeMeshFV(S,[h1,h2,h3];x0=[x1,x2,x3])
     return mesh
 end

--- a/src/OcTreeMeshFV.jl
+++ b/src/OcTreeMeshFV.jl
@@ -64,9 +64,9 @@ mutable struct OcTreeMeshFV{T<:Real,N<:Integer,N2<:Integer} <: OcTreeMesh
 	L::SparseMatrixCSC{T,N} # edge lengths
 	Ne::SparseMatrixCSC{T,N} # Edge nullspace matrix
 	Qe::SparseMatrixCSC{T,N} # Edge projection matrix
-	activeEdges::Vector{N2}   # lookup table for new edge enumeration
-	activeFaces::Vector{N2}   # lookup table for new face enumeration
-	activeNodes::Vector{N2}   # lookup table for new node enumeration
+	activeEdges::Vector{N}   # lookup table for new edge enumeration
+	activeFaces::Vector{N}   # lookup table for new face enumeration
+	activeNodes::Vector{N}   # lookup table for new node enumeration
 	Nn::SparseMatrixCSC{T,N} # Node nullspace matrix
 	Qn::SparseMatrixCSC{T,N} # Node projection matrix
 	Nf::SparseMatrixCSC{T,N} # Face nullspace matrix
@@ -120,7 +120,7 @@ function getOcTreeMeshFV{T<:Real,N<:Integer,N2<:Integer}(S::SparseArray3D{N,N2},
                         Dict{Int64,MassMatrix{T,N}}(), # no Pn
                         empt,empt,empt,   # no Af,Ae,An
                         empt,empt,empt,empt, # no V,L,Ne,Qe,
-                        N2[],N2[],N2[],  # no active edges, active faces, active nodes
+                        N[],N[],N[],  # no active edges, active faces, active nodes
                         empt,empt,empt,empt, #no Nn,Qn,Nf,Qf
                         FX,FY,FZ,
                         EX,EY,EZ,

--- a/src/OcTreeMeshFV.jl
+++ b/src/OcTreeMeshFV.jl
@@ -109,10 +109,10 @@ function getOcTreeMeshFV{T<:Number,N<:Integer,N2<:Integer}(S::SparseArray3D{N,N2
 	nn = N(nnz(NN))
 
 	empt  = spzeros(T,N,0,0)
-    sz    = [size(S,1),size(S,2),size(S,3)]
+    sz    = (size(S,1),size(S,2),size(S,3))
 	empt3 = SparseArray3D(spzeros(N,N2,prod(sz)),sz)
 
-		return OcTreeMeshFV(S, h, x0, S.sz,
+		return OcTreeMeshFV(S, h, x0, collect(S.sz),
                         nc,nf,ne,nn,
                         empt,empt,empt,       # no Div, Grad, Curl
                         Dict{Int64,MassMatrix{T,N}}(), # no Pf
@@ -165,20 +165,20 @@ function clear!(M::OcTreeMeshFV; exclude::Vector{Symbol} = Vector{Symbol}())
   if !(:Qn          in exclude) M.Qn          = spzeros(0,0);             end
   if !(:Nf          in exclude) M.Nf          = spzeros(0,0);             end
   if !(:Qf          in exclude) M.Qf          = spzeros(0,0);             end
-  if !(:FX          in exclude) M.FX          = sparse3([0,0,0]);         end
-  if !(:FY          in exclude) M.FY          = sparse3([0,0,0]);         end
-  if !(:FZ          in exclude) M.FZ          = sparse3([0,0,0]);         end
-  if !(:EX          in exclude) M.EX          = sparse3([0,0,0]);         end
-  if !(:EY          in exclude) M.EY          = sparse3([0,0,0]);         end
-  if !(:EZ          in exclude) M.EZ          = sparse3([0,0,0]);         end
-  if !(:NC          in exclude) M.NC          = sparse3([0,0,0]);         end
-  if !(:NFX         in exclude) M.NFX         = sparse3([0,0,0]);         end
-  if !(:NFY         in exclude) M.NFY         = sparse3([0,0,0]);         end
-  if !(:NFZ         in exclude) M.NFZ         = sparse3([0,0,0]);         end
-  if !(:NEX         in exclude) M.NEX         = sparse3([0,0,0]);         end
-  if !(:NEY         in exclude) M.NEY         = sparse3([0,0,0]);         end
-  if !(:NEZ         in exclude) M.NEZ         = sparse3([0,0,0]);         end
-  if !(:NN          in exclude) M.NN          = sparse3([0,0,0]);         end
+  if !(:FX          in exclude) M.FX          = sparse3((0,0,0));         end
+  if !(:FY          in exclude) M.FY          = sparse3((0,0,0));         end
+  if !(:FZ          in exclude) M.FZ          = sparse3((0,0,0));         end
+  if !(:EX          in exclude) M.EX          = sparse3((0,0,0));         end
+  if !(:EY          in exclude) M.EY          = sparse3((0,0,0));         end
+  if !(:EZ          in exclude) M.EZ          = sparse3((0,0,0));         end
+  if !(:NC          in exclude) M.NC          = sparse3((0,0,0));         end
+  if !(:NFX         in exclude) M.NFX         = sparse3((0,0,0));         end
+  if !(:NFY         in exclude) M.NFY         = sparse3((0,0,0));         end
+  if !(:NFZ         in exclude) M.NFZ         = sparse3((0,0,0));         end
+  if !(:NEX         in exclude) M.NEX         = sparse3((0,0,0));         end
+  if !(:NEY         in exclude) M.NEY         = sparse3((0,0,0));         end
+  if !(:NEZ         in exclude) M.NEZ         = sparse3((0,0,0));         end
+  if !(:NN          in exclude) M.NN          = sparse3((0,0,0));         end
 
   return
 

--- a/src/OcTreeMeshFV.jl
+++ b/src/OcTreeMeshFV.jl
@@ -20,7 +20,7 @@ Fields
  - `colptr::Array{Integer,1}`: CSC format column pointers in `M`
  - `colval::Array{Integer,1}`: column indices of nonzero entries in `M`
 """
-struct MassMatrix{T<:Real,N<:Integer}
+struct MassMatrix{T<:Number,N<:Integer}
     n::Int
     A::SparseMatrixCSC{T,N}
     rowval::Array{N,1}
@@ -34,7 +34,7 @@ end
 
 Default constructor for `MassMatrix`
 """
-function MassMatrix(T::Type{t},N::Type{n}) where t <: Real where n <: Integer
+function MassMatrix(T::Type{t},N::Type{n}) where t <: Number where n <: Integer
     F = Array{T}(0)
     I = Array{T}(0)
     S = SparseMatrixCSC(0, 0, N[1], I, F)
@@ -42,7 +42,7 @@ function MassMatrix(T::Type{t},N::Type{n}) where t <: Real where n <: Integer
 end
 
 
-mutable struct OcTreeMeshFV{T<:Real,N<:Integer,N2<:Integer} <: OcTreeMesh
+mutable struct OcTreeMeshFV{T<:Number,N<:Integer,N2<:Integer} <: OcTreeMesh
 	S::SparseArray3D{N,N2}    # i,j,k, bsz
 	h::Vector{T}  # (3) underlying cell size
 	x0::Vector{T} # coordinates of corner of mesh
@@ -89,7 +89,7 @@ mutable struct OcTreeMeshFV{T<:Real,N<:Integer,N2<:Integer} <: OcTreeMesh
 end # type OcTreeMeshFV
 
 
-function getOcTreeMeshFV{T<:Real,N<:Integer,N2<:Integer}(S::SparseArray3D{N,N2},
+function getOcTreeMeshFV{T<:Number,N<:Integer,N2<:Integer}(S::SparseArray3D{N,N2},
                          h::Vector{T};x0::Vector{T}=zeros(T,3))
 
     # get number of cells
@@ -133,7 +133,7 @@ end  # function getOcTreeMeshFV
 
 import Base.clear!
 function clear!(M::OcTreeMeshFV; exclude::Vector{Symbol} = Vector{Symbol}())
-  
+
   # Don't clear the essential mesh information:
   # if !(:S           in exclude) M.S           = sparse3([0,0,0]);        end
   # if !(:h           in exclude) M.h           = zeros(3);                end
@@ -143,7 +143,7 @@ function clear!(M::OcTreeMeshFV; exclude::Vector{Symbol} = Vector{Symbol}())
   # if !(:nf          in exclude) M.nf          = [0,0,0];                 end
   # if !(:ne          in exclude) M.ne          = [0,0,0];                 end
   # if !(:nn          in exclude) M.nn          = 0;                       end
-  
+
   # Clear all derived variables
   if !(:Div         in exclude) M.Div         = spzeros(0,0);             end
   if !(:Grad        in exclude) M.Grad        = spzeros(0,0);             end

--- a/src/OcTreeMeshFV.jl
+++ b/src/OcTreeMeshFV.jl
@@ -13,19 +13,19 @@ Internal storage for mass matrix integration
  - `M = getFaceMassMatrix(mesh, sigma)`
 
 Fields
- - `n::Int64`: size of mass matrix `M` (number of nodes, edges, faces in `mesh`)
- - `A::SparseMatrixCSC{Float64,Int64}`: map coefficient vector `sigma` to
+ - `n::Integer`: size of mass matrix `M` (number of nodes, edges, faces in `mesh`)
+ - `A::SparseMatrixCSC{Float64,Integer}`: map coefficient vector `sigma` to
       nonzero entries in mass matrix `M` (numerical integration)
- - `rowval::Array{Int64,1}`: row indices of nonzero entries in `M`
- - `colptr::Array{Int64,1}`: CSC format column pointers in `M`
- - `colval::Array{Int64,1}`: column indices of nonzero entries in `M`
+ - `rowval::Array{Integer,1}`: row indices of nonzero entries in `M`
+ - `colptr::Array{Integer,1}`: CSC format column pointers in `M`
+ - `colval::Array{Integer,1}`: column indices of nonzero entries in `M`
 """
-struct MassMatrix
-    n::Int64
-    A::SparseMatrixCSC{Float64,Int64}
-    rowval::Array{Int64,1}
-    colptr::Array{Int64,1}
-    colval::Array{Int64,1}
+struct MassMatrix{T<:Real,N<:Integer}
+    n::Int
+    A::SparseMatrixCSC{T,N}
+    rowval::Array{N,1}
+    colptr::Array{N,1}
+    colval::Array{N,1}
 end
 
 
@@ -34,91 +34,93 @@ end
 
 Default constructor for `MassMatrix`
 """
-function MassMatrix()
-    F = Array{Float64}(0)
-    I = Array{Int64}(0)
-    S = SparseMatrixCSC(0, 0, [1], I, F)
+function MassMatrix(T::Type{t},N::Type{n}) where t <: Real where n <: Integer
+    F = Array{T}(0)
+    I = Array{T}(0)
+    S = SparseMatrixCSC(0, 0, N[1], I, F)
     return MassMatrix(0, S, I, I, I)
 end
 
 
-mutable struct OcTreeMeshFV <: OcTreeMesh
-	S::SparseArray3D    # i,j,k, bsz
-	h::Vector{Float64}  # (3) underlying cell size
-	x0::Vector{Float64} # coordinates of corner of mesh
-	n::Vector{Int64} # underlying mesh
-	nc::Int          # number of cells
-	nf::Vector{Int}  # (3) number of faces
-	ne::Vector{Int}  # (3) number of edges
-  nn::Int          # number of nodes
-	Div::SparseMatrixCSC
-	Grad::SparseMatrixCSC
-	Curl::SparseMatrixCSC
-	Pf::Dict{Int64,MassMatrix} # face mass matrix integration storage
-	Pe::Dict{Int64,MassMatrix} # edge mass matrix integration storage
-	Pn::Dict{Int64,MassMatrix} # nodal mass matrix integration storage
-	Af::SparseMatrixCSC # Face to cell-centre matrix
-	Ae::SparseMatrixCSC # Edge to cell-centre matrix
-	An::SparseMatrixCSC # Node to cell-centre matrix
-	V::SparseMatrixCSC # cell volume
-	L::SparseMatrixCSC # edge lengths
-	Ne::SparseMatrixCSC # Edge nullspace matrix
-	Qe::SparseMatrixCSC # Edge projection matrix
-	activeEdges::Vector{Int64}   # lookup table for new edge enumeration
-	activeFaces::Vector{Int64}   # lookup table for new face enumeration
-	activeNodes::Vector{Int64}   # lookup table for new node enumeration
-	Nn::SparseMatrixCSC # Node nullspace matrix
-	Qn::SparseMatrixCSC # Node projection matrix
-	Nf::SparseMatrixCSC # Face nullspace matrix
-	Qf::SparseMatrixCSC # Face projection matrix
-	FX::SparseArray3D  # X face size
-	FY::SparseArray3D  # Y face size
-	FZ::SparseArray3D  # Z face size
-	EX::SparseArray3D  # X edge size
-	EY::SparseArray3D  # Y edge size
-	EZ::SparseArray3D  # Z edge size
-  NC::SparseArray3D  # CellNumbering
-	NFX::SparseArray3D # X FaceNumbering
-	NFY::SparseArray3D # Y FaceNumbering
-	NFZ::SparseArray3D # Z FaceNumbering
-	NEX::SparseArray3D # X EdgeNumbering
-	NEY::SparseArray3D # Y EdgeNumbering
-	NEZ::SparseArray3D # Z EdgeNumbering
-  NN::SparseArray3D  # NodalNumbering
-	dim::Int           # Mesh dimension
+mutable struct OcTreeMeshFV{T<:Real,N<:Integer,N2<:Integer} <: OcTreeMesh
+	S::SparseArray3D{N,N2}    # i,j,k, bsz
+	h::Vector{T}  # (3) underlying cell size
+	x0::Vector{T} # coordinates of corner of mesh
+	n::Vector{N2} # underlying mesh
+	nc::N          # number of cells
+	nf::Vector{N}  # (3) number of faces
+	ne::Vector{N}  # (3) number of edges
+    nn::N          # number of nodes
+	Div::SparseMatrixCSC{T,N}
+	Grad::SparseMatrixCSC{T,N}
+	Curl::SparseMatrixCSC{T,N}
+	Pf::Dict{Int64,MassMatrix{T,N}} # face mass matrix integration storage
+	Pe::Dict{Int64,MassMatrix{T,N}} # edge mass matrix integration storage
+	Pn::Dict{Int64,MassMatrix{T,N}} # nodal mass matrix integration storage
+	Af::SparseMatrixCSC{T,N} # Face to cell-centre matrix
+	Ae::SparseMatrixCSC{T,N} # Edge to cell-centre matrix
+	An::SparseMatrixCSC{T,N} # Node to cell-centre matrix
+	V::SparseMatrixCSC{T,N} # cell volume
+	L::SparseMatrixCSC{T,N} # edge lengths
+	Ne::SparseMatrixCSC{T,N} # Edge nullspace matrix
+	Qe::SparseMatrixCSC{T,N} # Edge projection matrix
+	activeEdges::Vector{N2}   # lookup table for new edge enumeration
+	activeFaces::Vector{N2}   # lookup table for new face enumeration
+	activeNodes::Vector{N2}   # lookup table for new node enumeration
+	Nn::SparseMatrixCSC{T,N} # Node nullspace matrix
+	Qn::SparseMatrixCSC{T,N} # Node projection matrix
+	Nf::SparseMatrixCSC{T,N} # Face nullspace matrix
+	Qf::SparseMatrixCSC{T,N} # Face projection matrix
+	FX::SparseArray3D{N,N2}  # X face size
+	FY::SparseArray3D{N,N2}  # Y face size
+	FZ::SparseArray3D{N,N2}  # Z face size
+	EX::SparseArray3D{N,N2}  # X edge size
+	EY::SparseArray3D{N,N2}  # Y edge size
+	EZ::SparseArray3D{N,N2}  # Z edge size
+    NC::SparseArray3D{N,N2}  # CellNumbering
+	NFX::SparseArray3D{N,N2} # X FaceNumbering
+	NFY::SparseArray3D{N,N2} # Y FaceNumbering
+	NFZ::SparseArray3D{N,N2} # Z FaceNumbering
+	NEX::SparseArray3D{N,N2} # X EdgeNumbering
+	NEY::SparseArray3D{N,N2} # Y EdgeNumbering
+	NEZ::SparseArray3D{N,N2} # Z EdgeNumbering
+    NN::SparseArray3D{N,N2}  # NodalNumbering
+	dim::N           # Mesh dimension
 end # type OcTreeMeshFV
 
 
-function getOcTreeMeshFV(S,h;x0=zeros(3))
+function getOcTreeMeshFV{T<:Real,N<:Integer,N2<:Integer}(S::SparseArray3D{N,N2},
+                         h::Vector{T};x0::Vector{T}=zeros(T,3))
 
     # get number of cells
     NC = getCellNumbering(S)
-    nc = nnz(NC)
+    nc = N(nnz(NC))
 
-		# get number of faces
+	# get number of faces
     FX,FY,FZ, NFX, NFY, NFZ = getFaceSizeNumbering(S)
-		nf = [nnz(FX), nnz(FY), nnz(FZ)]
+	nf = convert(Vector{N},[nnz(FX), nnz(FY), nnz(FZ)])
 
-		# get number of edges
+	# get number of edges
     EX,EY,EZ, NEX, NEY, NEZ = getEdgeSizeNumbering(S)
-		ne = [nnz(EX), nnz(EY), nnz(EZ)]
+	ne = convert(Vector{N},[nnz(EX), nnz(EY), nnz(EZ)])
 
-		# get number of nodes
+	# get number of nodes
     NN = getNodalNumbering(S)
-		nn = nnz(NN)
+	nn = N(nnz(NN))
 
-		empt = spzeros(0,0)
-		empt3 = sparse3([size(S,1),size(S,2),size(S,3)])
+	empt  = spzeros(T,N,0,0)
+    sz    = [size(S,1),size(S,2),size(S,3)]
+	empt3 = SparseArray3D(spzeros(N,N2,prod(sz)),sz)
 
 		return OcTreeMeshFV(S, h, x0, S.sz,
                         nc,nf,ne,nn,
                         empt,empt,empt,       # no Div, Grad, Curl
-                        Dict{Int64,MassMatrix}(), # no Pf
-                        Dict{Int64,MassMatrix}(), # no Pe
-                        Dict{Int64,MassMatrix}(), # no Pn
+                        Dict{Int64,MassMatrix{T,N}}(), # no Pf
+                        Dict{Int64,MassMatrix{T,N}}(), # no Pe
+                        Dict{Int64,MassMatrix{T,N}}(), # no Pn
                         empt,empt,empt,   # no Af,Ae,An
                         empt,empt,empt,empt, # no V,L,Ne,Qe,
-                        Int64[],Int64[],Int64[],  # no active edges, active faces, active nodes
+                        N2[],N2[],N2[],  # no active edges, active faces, active nodes
                         empt,empt,empt,empt, #no Nn,Qn,Nf,Qf
                         FX,FY,FZ,
                         EX,EY,EZ,
@@ -126,7 +128,7 @@ function getOcTreeMeshFV(S,h;x0=zeros(3))
                         NFX, NFY, NFZ,
                         NEX, NEY, NEZ,
                         NN,
-                        3)
+                        N(3))
 end  # function getOcTreeMeshFV
 
 import Base.clear!

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -148,3 +148,14 @@ function merge!(a::Vector{T}, b::Vector{T}) where T <: Number
     end
   end
 end
+
+import Base.speye
+speye(Tt::Type{T}, Tn::Type{N}, m::Integer) where T where N = speye(Tt, Tn, m, m)
+function speye(::Type{T}, ::Type{N}, m::Integer, n::Integer) where T where N
+    ((m < 0) || (n < 0)) && throw(ArgumentError("invalid array dimensions"))
+    nnz = min(m,n)
+    colptr = Vector{N}(1+n)
+    colptr[1:nnz+1] = 1:nnz+1
+    colptr[nnz+2:end] = nnz+1
+    SparseMatrixCSC(Int(m), Int(n), colptr, Vector{N}(1:nnz), ones(T,nnz))
+end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -123,7 +123,13 @@ end
 
 # Internal utilities
 
-function getNodesFromIndices(sv,mm,i0::Vector,j0::Vector,k0::Vector)
+function getNodesFromIndices(sv,mm::Tuple,i0::Vector,j0::Vector,k0::Vector)
+    Ti = promote_type(eltype(mm),promote_type(eltype(i0),
+                      promote_type(eltype(j0),eltype(k0))))
+    mm = (Ti(mm[1]),Ti(mm[2]),Ti(mm[3]))
+    i0 = convert(Vector{Ti},i0)
+    j0 = convert(Vector{Ti},j0)
+    k0 = convert(Vector{Ti},k0)
 	jj = sub2ind(mm,i0,j0,k0)
     v  = Array{eltype(sv)}(length(jj))
     for i = 1:length(jj)

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -123,15 +123,13 @@ end
 
 # Internal utilities
 
-function getNodesFromIndices(sv,mm,i0::Vector{Int},j0::Vector{Int},k0::Vector{Int})
-
+function getNodesFromIndices(sv,mm,i0::Vector,j0::Vector,k0::Vector)
 	jj = sub2ind(mm,i0,j0,k0)
-  v  = Array{Int64}(length(jj))
-  for i = 1:length(jj)
-    v[i] = sv[jj[i]]
-  end
+    v  = Array{eltype(sv)}(length(jj))
+    for i = 1:length(jj)
+        v[i] = sv[jj[i]]
+    end
 	return v
-
 end
 
 """
@@ -139,7 +137,7 @@ end
 
 Replace zero entries in `a` by values from `b`.
 """
-function merge!(a::Vector{Int64}, b::Vector{Int64})
+function merge!(a::Vector{T}, b::Vector{T}) where T <: Number
   n = length(a)
   (length(b) == n) || throw(DimensionMismatch("length(a) != length(b)"))
   @inbounds begin

--- a/src/createOcTree/createOcTreeFromBox.jl
+++ b/src/createOcTree/createOcTreeFromBox.jl
@@ -8,7 +8,7 @@ function createOcTreeFromBox(
   ya::AbstractFloat, yb::AbstractFloat,
   za::AbstractFloat, zb::AbstractFloat,
   nf::Array{N2,1}, nc::Array{N2,1},
-  bsz::Integer = 1,operatorIntType::Type{N}=Int32) where N <: Integer where N2 <:Integer
+  bsz::Integer = 1,operatorIntType::Type{N}=Int64) where N <: Integer where N2 <:Integer
 # S = createOcTreeFromBox( ...
 #   x0, y0, z0, nx, ny, nz, hx, hy, hz, xa, xb, ya, yb, za, zb, nf, nc)
 #
@@ -234,7 +234,7 @@ createOcTreeFromBox(
   nf::Integer,
   nc::Integer,
   bsz::Integer = 1,
-  operatorIntType::Type{N}=Int32) where N <: Integer =
+  operatorIntType::Type{N}=Int64) where N <: Integer =
 createOcTreeFromBox(
   x0, y0, z0,
   nx, ny, nz,

--- a/src/createOcTree/initializeOctree.jl
+++ b/src/createOcTree/initializeOctree.jl
@@ -33,7 +33,7 @@ function initializeOctree( n::Vector{Int64}, bsz::Int64=0)
     end
 
     i,j,k = ndgrid(1:nb:n[1], 1:nb:n[2], 1:nb:n[3])
-    b = fill(nb, length(i))
+    b = fill(Int32(nb), length(i))
 
     S = sparse3(vec(i),vec(j),vec(k), b, n)
     return S

--- a/src/createOcTree/initializeOctree.jl
+++ b/src/createOcTree/initializeOctree.jl
@@ -15,7 +15,10 @@ export initializeOctree
         S::SparseArray3D
 
 """
-function initializeOctree( n::Vector{Int64}, bsz::Int64=0)
+initializeOctree(n::Tuple{Integer,Integer,Integer}, bsz::Integer=0) =
+                  initializeOctree(Int,Int,n,bsz)
+function initializeOctree{Tn<:Integer,Tn2<:Integer}(::Type{Tn}, ::Type{Tn2},
+                              n::Tuple{Integer,Integer,Integer}, bsz::Integer=0)
 
     if !(ispow2(n[1]) && ispow2(n[2]) && ispow2(n[3]))
         error("n must be power of 2.")
@@ -33,8 +36,10 @@ function initializeOctree( n::Vector{Int64}, bsz::Int64=0)
     end
 
     i,j,k = ndgrid(1:nb:n[1], 1:nb:n[2], 1:nb:n[3])
-    b = fill(Int32(nb), length(i))
-
-    S = sparse3(vec(i),vec(j),vec(k), b, n)
+    b = fill(Tn(nb), length(i))
+    i = convert(Vector{Tn2},vec(i))
+    j = convert(Vector{Tn2},vec(j))
+    k = convert(Vector{Tn2},vec(k))
+    S = sparse3(i,j,k, b, (Tn2(n[1]),Tn2(n[2]),Tn2(n[3])))
     return S
 end

--- a/src/findBlocks.jl
+++ b/src/findBlocks.jl
@@ -28,7 +28,7 @@ function findBlocks(S::SparseArray3D,i::Vector,j::Vector,k::Vector)
 		if isempty(Iz)
 			break
 		end
-	    t               = S.SV[sub2ind((S.sz[1],S.sz[2],S.sz[3]),bi[Iz],bj[Iz],bk[Iz])]
+	    t               = S.SV[sub2ind(S.sz,bi[Iz],bj[Iz],bk[Iz])]
 	    indnz           = find(t .!= 0)
 	    indz            = find(t .== 0)
 	    bsz[Iz[indnz]]  = t[indnz]
@@ -54,12 +54,11 @@ function findBlocks(S::SparseArray3D, i::Integer,j::Integer,k::Integer)
 	bj  = Tn2(j)
 	bk  = Tn2(k)
 
-	sz = (S.sz[1], S.sz[2], S.sz[3])
 	block = one(Tn2)
 
 	while true
 
-		bsz = S.SV[sub2ind(sz, bi,bj,bk)]
+		bsz = S.SV[sub2ind(S.sz, bi,bj,bk)]
 		if bsz != 0
 			break
 		end

--- a/src/findBlocks.jl
+++ b/src/findBlocks.jl
@@ -2,58 +2,61 @@ export findBlocks
 
 
 
-function findBlocks(S::SparseArray3D,i::Vector{Int},j::Vector{Int},k::Vector{Int})
+function findBlocks(S::SparseArray3D,i::Vector,j::Vector,k::Vector)
 # [bi,bj,bk,bsz] = findBlocks(S,i,j,k) # search the the blocks in S that covers the indices (i,j,k)
+    Tn  = eltype(S.SV.nzval)
+	Tn2 = eltype(S.SV.nzind)
 	n   = length(i)
-	bsz = zeros(Int,n)
+	bsz = zeros(Tn,n)
 	bi  = copy(i)
 	bj  = copy(j)
 	bk  = copy(k)
-	
+
 	# find indices outside the domain
 	I = find( (bi.<1) .| (S.sz[1].<bi) .| (bj.<1) .| (S.sz[2].<bj) .| (bk.<1) .| (S.sz[3].<bk) )
 	if !isempty(I)
-		bsz[I] = -1
-		bi[I]  = -1
-		bj[I]  = -1
-		bk[I]  = -1
+		bsz[I] = -one(Tn)
+		bi[I]  = -one(Tn2)
+		bj[I]  = -one(Tn2)
+		bk[I]  = -one(Tn2)
 	end
-	
-	block = 1
-	
+
+	block = one(Tn2)
+
 	while true
 	    Iz = find(bsz.==0)
 		if isempty(Iz)
-			break 
+			break
 		end
 	    t               = S.SV[sub2ind((S.sz[1],S.sz[2],S.sz[3]),bi[Iz],bj[Iz],bk[Iz])]
 	    indnz           = find(t .!= 0)
 	    indz            = find(t .== 0)
 	    bsz[Iz[indnz]]  = t[indnz]
-	    
-	    block *= 2
+
+	    block *= Tn2(2)
 		Iz = Iz[indz]
-	    bi[Iz] = 1 .+ block * floor.(Integer,(i[Iz].-1)/block)
-	    bj[Iz] = 1 .+ block * floor.(Integer,(j[Iz].-1)/block)
-	    bk[Iz] = 1 .+ block * floor.(Integer,(k[Iz].-1)/block)
+	    bi[Iz] = one(Tn2) .+ block * floor.(Tn2,(i[Iz].-1)/block)
+	    bj[Iz] = one(Tn2) .+ block * floor.(Tn2,(j[Iz].-1)/block)
+	    bk[Iz] = one(Tn2) .+ block * floor.(Tn2,(k[Iz].-1)/block)
 	end
 	return bi,bj,bk,bsz
 end
 
-function findBlocks(S::SparseArray3D, i::Int,j::Int,k::Int)
-
-	if (i < 1) | (i > S.sz[1]) | (j < 1) | (j > S.sz[2]) | (k < 1) | (k > S.sz[3]) 
-		return -1, -1, -1, -1
+function findBlocks(S::SparseArray3D, i::Integer,j::Integer,k::Integer)
+	Tn  = eltype(S.SV.nzval)
+	Tn2 = eltype(S.SV.nzind)
+	if (i < 1) | (i > S.sz[1]) | (j < 1) | (j > S.sz[2]) | (k < 1) | (k > S.sz[3])
+		return -one(Tn2), -one(Tn2), -one(Tn2), -one(Tn2)
 	end
-	
-	bsz = 0
-	bi  = i
-	bj  = j
-	bk  = k
+
+	bsz = zero(Tn)
+	bi  = Tn2(i)
+	bj  = Tn2(j)
+	bk  = Tn2(k)
 
 	sz = (S.sz[1], S.sz[2], S.sz[3])
-	block = 1
-	
+	block = one(Tn2)
+
 	while true
 
 		bsz = S.SV[sub2ind(sz, bi,bj,bk)]
@@ -61,12 +64,12 @@ function findBlocks(S::SparseArray3D, i::Int,j::Int,k::Int)
 			break
 		end
 
-		block *= 2
-		bi     = 1 + block * div(i-1, block)
-		bj     = 1 + block * div(j-1, block)
-		bk     = 1 + block * div(k-1, block)           
-		
-		end
-	
+		block *= Tn2(2)
+		bi     = Tn2(1) + block * div(i-1, block)
+		bj     = Tn2(1) + block * div(j-1, block)
+		bk     = Tn2(1) + block * div(k-1, block)
+
+	end
+
 	return bi,bj,bk,bsz
 end

--- a/src/getCellCenterGradientMatrix.jl
+++ b/src/getCellCenterGradientMatrix.jl
@@ -7,15 +7,17 @@ function getCellCenterXGradientMatrix(Mesh::OcTreeMeshFV)
     CN = getCellNumbering(Mesh)
     FXN, FYN, FZN = getFaceNumbering(Mesh)
     i, j, k, bsz = find3(Mesh.S)
+    Tn  = eltype(bsz)
+    Tf  = eltype(Mesh.h)
 
     upper, lower, left, right, front, back = getSizeOfNeighbors(Mesh.S)
 
     ######################################################################
     #### GRAD ON X-FACES
     ######################################################################
-    ii = Int[]
-    jj = Int[]
-    vv = Float64[]
+    ii = Tn[]
+    jj = Tn[]
+    vv = Tf[]
 
     # cells with the same size
     I = (upper .== 1)
@@ -87,8 +89,8 @@ function getCellCenterXGradientMatrix(Mesh::OcTreeMeshFV)
         end
     end
 
-    mii = Array{Int}(length(ii))
-    mjj = Array{Int}(length(jj))
+    mii = Array{Tn}(length(ii))
+    mjj = Array{Tn}(length(jj))
     for c in 1:length(ii)
         mii[c] = FXN.SV[ii[c]]
         mjj[c] = CN.SV[jj[c]]
@@ -103,15 +105,17 @@ function getCellCenterYGradientMatrix(Mesh::OcTreeMeshFV)
     CN = getCellNumbering(Mesh)
     FXN, FYN, FZN = getFaceNumbering(Mesh)
     i, j, k, bsz = find3(Mesh.S)
+    Tn  = eltype(bsz)
+    Tf  = eltype(Mesh.h)
 
     upper, lower, left, right, front, back = getSizeOfNeighbors(Mesh.S)
 
     ######################################################################
     #### GRAD ON Y-FACES
     ######################################################################
-    ii = Int[]
-    jj = Int[]
-    vv = Float64[]
+    ii = Tn[]
+    jj = Tn[]
+    vv = Tf[]
 
     # cells with the same size
     I = (left .== 1)
@@ -184,8 +188,8 @@ function getCellCenterYGradientMatrix(Mesh::OcTreeMeshFV)
     end
 
 
-    mii = Array{Int}(length(ii))
-    mjj = Array{Int}(length(jj))
+    mii = Array{Tn}(length(ii))
+    mjj = Array{Tn}(length(jj))
     for c in 1:length(ii)
         mii[c] = FYN.SV[ii[c]]
         mjj[c] = CN.SV[jj[c]]
@@ -200,15 +204,16 @@ function getCellCenterZGradientMatrix(Mesh::OcTreeMeshFV)
     CN = getCellNumbering(Mesh)
     FXN, FYN, FZN = getFaceNumbering(Mesh)
     i, j, k, bsz = find3(Mesh.S)
-
+    Tn  = eltype(bsz)
+    Tf  = eltype(Mesh.h)
     upper, lower, left, right, front, back = getSizeOfNeighbors(Mesh.S)
 
     ######################################################################
     #### GRAD ON Z-FACES
     ######################################################################
-    ii = Int[]
-    jj = Int[]
-    vv = Float64[]
+    ii = Tn[]
+    jj = Tn[]
+    vv = Tf[]
 
     # cells with the same size
     I = (front .== 1)
@@ -280,8 +285,8 @@ function getCellCenterZGradientMatrix(Mesh::OcTreeMeshFV)
         end
     end
 
-    mii = Array{Int}(length(ii))
-    mjj = Array{Int}(length(jj))
+    mii = Array{Tn}(length(ii))
+    mjj = Array{Tn}(length(jj))
     for c in 1:length(ii)
         mii[c] = FZN.SV[ii[c]]
         mjj[c] = CN.SV[jj[c]]
@@ -297,10 +302,11 @@ function getCellCenterGradientMatrix(Mesh::OcTreeMeshFV)
     GX = getCellCenterXGradientMatrix(Mesh)
     GY = getCellCenterYGradientMatrix(Mesh)
     GZ = getCellCenterZGradientMatrix(Mesh)
-
+    Tn = eltype(Gx.colptr)
+    Tf = eltype(Gx.nzval)
     nx, ny, nz = Mesh.nf
 
-    GRAD = spzeros(sum(Mesh.nf), Mesh.nc)
+    GRAD = spzeros(Tf,Tn,sum(Mesh.nf), Mesh.nc)
     GRAD[1:nx, :] = GX
     GRAD[nx+1:nx+ny, :] = GY
     GRAD[nx+ny+1:nx+ny+nz, :] = GZ

--- a/src/getCurlMatrixRec.jl
+++ b/src/getCurlMatrixRec.jl
@@ -14,7 +14,8 @@ function getCurlMatrixRec(M)
 # [CURL,T,ESZ,FSZ] = getCurlMatrix(S)
 
 S = M.S; h = M.h
-
+Tn = eltype(S.SV.nzval)
+Tf = eltype(h)
 m1,m2,m3    = S.sz
 FX,FY,FZ, NFX,NFY,NFZ = getFaceSizeNumbering(M)
 EX,EY,EZ, NEX,NEY,NEZ = getEdgeSizeNumbering(M)
@@ -39,8 +40,8 @@ fn        = nonzeros(NFX)
 
 front    = NEY.SV[sub2ind(NEY.sz,i,j,k)];  front = vec(full(front))
 back     = NEY.SV[sub2ind(NEY.sz,i,j,k+fsz)];  back  = vec(full(back))
-frontmid = zeros(Int64, length(front))
-backmid  = zeros(Int64, length(back))
+frontmid = zeros(Tn, length(front))
+backmid  = zeros(Tn, length(back))
 
 I =  (j+div.(fsz,2) .<= m2) .& (fsz .>= 2)
 if any(I)
@@ -56,7 +57,7 @@ Ib2 = (backmid .>  0)  # 2 BACKSIDE EDGES PER FACE
 
 ii = [fn[If1];       fn[If2];           fn[If2];            fn[Ib1];        fn[Ib2];            fn[Ib2]          ]
 jj = [front[If1];    front[If2];        frontmid[If2];      back[Ib1];      back[Ib2];          backmid[Ib2]     ]
-vv = [-ones(sum(If1));  -ones(sum(If2));  -ones(sum(If2)); ones(sum(Ib1));    ones(sum(Ib2));    ones(sum(Ib2))]
+vv = [-ones(Tf,sum(If1)); -ones(Tf,sum(If2)); -ones(sum(Tf,If2)); ones(Tf,sum(Ib1)); ones(Tf,sum(Ib2)); ones(Tf,sum(Ib2))]
 
 DYZ = sparse(ii, jj, vv,nnz(NFX),nnz(NEY))
 
@@ -70,8 +71,8 @@ DYZ = sparse(ii, jj, vv,nnz(NFX),nnz(NEY))
 
 left     = NEZ.SV[sub2ind(NEZ.sz,i,j,k    )];  left  = vec(full(left))
 right    = NEZ.SV[sub2ind(NEZ.sz,i,j+fsz,k)];  right = vec(full(right))
-leftmid  = zeros(Int64, length(left))
-rightmid = zeros(Int64, length(right))
+leftmid  = zeros(Tn, length(left))
+rightmid = zeros(Tn, length(right))
 
 I = (j+div.(fsz,2) .<= m2) .& (fsz .>= 2)
 if any(I)
@@ -85,7 +86,7 @@ Ir2 = (rightmid .>  0) # 2 RIGHT EDGES PER FACE
 
 ii = [fn[Il1];  fn[Il2];  fn[Il2];  fn[Ir1];  fn[Ir2];  fn[Ir2]   ]
 jj = [left[Il1];  left[Il2];   leftmid[Il2];  right[Ir1];  right[Ir2];  rightmid[Ir2] ]
-vv = [-ones(sum(Il1)); -ones(sum(Il2));  -ones(sum(Il2));  ones(sum(Ir1)); ones(sum(Ir2));  ones(sum(Ir2))  ]
+vv = [-ones(Tf,sum(Il1)); -ones(Tf,sum(Il2)); -ones(Tf,sum(Il2)); ones(Tf,sum(Ir1)); ones(Tf,sum(Ir2)); ones(Tf,sum(Ir2)) ]
 
 DZY = sparse(ii, jj, vv,nnz(NFX),nnz(NEZ))
 
@@ -113,8 +114,8 @@ fn        = nonzeros(NFY)
 
 front    = NEX.SV[sub2ind(NEX.sz,i,j,k    )];  front = vec(full(front))
 back     = NEX.SV[sub2ind(NEX.sz,i,j,k+fsz)];  back  = vec(full(back));
-frontmid = zeros(Int64, length(front))
-backmid  = zeros(Int64, length(back))
+frontmid = zeros(Tn, length(front))
+backmid  = zeros(Tn, length(back))
 
 I = (i+div.(fsz,2) .<= m1) .& (fsz .>= 2)
 if any(I)
@@ -129,7 +130,7 @@ Ib2 = (backmid .>  0)   # 2 BACK EDGES PER FACE
 
 ii = [fn[If1];        fn[If2];           fn[If2];           fn[Ib1];        fn[Ib2];          fn[Ib2]          ]
 jj = [front[If1];     front[If2];        frontmid[If2];     back[Ib1];      back[Ib2];        backmid[Ib2]     ]
-vv = [-ones(sum(If1));   -ones(sum(If2));  -ones(sum(If2));  ones(sum(Ib1));    ones(sum(Ib2));  ones(sum(Ib2))];
+vv = [-ones(Tf,sum(If1)); -ones(Tf,sum(If2)); -ones(Tf,sum(If2)); ones(Tf,sum(Ib1)); ones(Tf,sum(Ib2)); ones(Tf,sum(Ib2))]
 
 DXZ = sparse(ii, jj, vv,nnz(NFY),nnz(NEX))
 
@@ -143,8 +144,8 @@ DXZ = sparse(ii, jj, vv,nnz(NFY),nnz(NEX))
 
 upper    = NEZ.SV[sub2ind(NEZ.sz,i    ,j,k)];  upper = vec(full(upper))
 lower    = NEZ.SV[sub2ind(NEZ.sz,i+fsz,j,k)];  lower = vec(full(lower))
-uppermid = zeros(Int64, length(upper))
-lowermid = zeros(Int64, length(lower))
+uppermid = zeros(Tn, length(upper))
+lowermid = zeros(Tn, length(lower))
 
 I = (i+div.(fsz,2) .<= m1) .& (fsz .>= 2)
 if any(I)
@@ -158,7 +159,7 @@ Il2 = (lowermid .>  0)  # 2 LOWER EDGES PER FACE
 
 ii = [fn[Iu1];        fn[Iu2];           fn[Iu2];           fn[Il1];        fn[Il2];          fn[Il2]          ]
 jj = [upper[Iu1];     upper[Iu2];        uppermid[Iu2];     lower[Il1];     lower[Il2];       lowermid[Il2]    ]
-vv = [-ones(sum(Iu1));   -ones(sum(Iu2));  -ones(sum(Iu2));  ones(sum(Il1)); ones(sum(Il2)); ones(sum(Il2))]
+vv = [-ones(Tf,sum(Iu1)); -ones(Tf,sum(Iu2)); -ones(Tf,sum(Iu2)); ones(Tf,sum(Il1)); ones(Tf,sum(Il2)); ones(Tf,sum(Il2))]
 
 DZX = sparse(ii, jj, vv,nnz(NFY),nnz(NEZ))
 
@@ -183,8 +184,8 @@ fn        = nonzeros(NFZ)
 
 left     = NEX.SV[sub2ind(NEX.sz,i,j,k    )];  left  = vec(full(left))
 right    = NEX.SV[sub2ind(NEX.sz,i,j+fsz,k)];  right = vec(full(right))
-leftmid  = zeros(Int64, length(left))
-rightmid = zeros(Int64, length(right))
+leftmid  = zeros(Tn, length(left))
+rightmid = zeros(Tn, length(right))
 
 I = (i+div.(fsz,2) .<= m1) .& (fsz .>= 2)
 
@@ -199,7 +200,7 @@ Ir2 = (rightmid .>  0) # 2 RIGHT EDGES PER FACE
 
 ii = [fn[Il1];        fn[Il2];           fn[Il2];           fn[Ir1];        fn[Ir2];          fn[Ir2]          ];
 jj = [left[Il1];      left[Il2];         leftmid[Il2];      right[Ir1];     right[Ir2];       rightmid[Ir2]    ];
-vv = [-ones(sum(Il1));   -ones(sum(Il2));  -ones(sum(Il2));  ones(sum(Ir1));    ones(sum(Ir2));  ones(sum(Ir2))]
+vv = [-ones(Tf,sum(Il1)); -ones(Tf,sum(Il2)); -ones(Tf,sum(Il2)); ones(Tf,sum(Ir1)); ones(Tf,sum(Ir2)); ones(Tf,sum(Ir2))]
 
 DXY = sparse(ii, jj, vv,nnz(NFZ),nnz(NEX))
 
@@ -212,8 +213,8 @@ DXY = sparse(ii, jj, vv,nnz(NFZ),nnz(NEX))
 
 upper    = NEY.SV[sub2ind(NEY.sz,i    ,j,k)];  upper = vec(full(upper))
 lower    = NEY.SV[sub2ind(NEY.sz,i+fsz,j,k)];  lower = vec(full(lower))
-uppermid = zeros(Int64, length(upper))
-lowermid = zeros(Int64, length(lower))
+uppermid = zeros(Tn, length(upper))
+lowermid = zeros(Tn, length(lower))
 
 I = (j+div.(fsz,2) .<= m2) .& (fsz .>= 2)
 if any(I)
@@ -227,7 +228,7 @@ Il2 = (lowermid .>  0)  # 2 LOWER EDGES PER FACE
 
 ii = [fn[Iu1];        fn[Iu2];           fn[Iu2];           fn[Il1];        fn[Il2];          fn[Il2]          ];
 jj = [upper[Iu1];     upper[Iu2];        uppermid[Iu2];     lower[Il1];     lower[Il2];       lowermid[Il2]    ];
-vv = [-ones(sum(Iu1));   -ones(sum(Iu2));  -ones(sum(Iu2));  ones(sum(Il1));   ones(sum(Il2));  ones(sum(Il2))];
+vv = [-ones(Tf,sum(Iu1)); -ones(Tf,sum(Iu2)); -ones(Tf,sum(Iu2)); ones(Tf,sum(Il1)); ones(Tf,sum(Il2)); ones(Tf,sum(Il2))]
 
 
 DYX = sparse(ii, jj, vv,nnz(NFZ),nnz(NEY))
@@ -241,7 +242,7 @@ ESZ  = vcat(nonzeros(EX)*h[1], nonzeros(EY)*h[2], nonzeros(EZ)*h[3])
 #FSZi = sdiag(1./[nonzeros(FX).^2*h[2]*h[3];
 #                 nonzeros(FY).^2*h[1]*h[3];
 #                 nonzeros(FZ).^2*h[1]*h[2]])
-FSZi = 1.0 ./ vcat(nonzeros(FX).^2*(h[2]*h[3]),
+FSZi = one(Tf) ./ vcat(nonzeros(FX).^2*(h[2]*h[3]),
                    nonzeros(FY).^2*(h[1]*h[3]),
                    nonzeros(FZ).^2*(h[1]*h[2]) )
 
@@ -254,7 +255,7 @@ FSZi = 1.0 ./ vcat(nonzeros(FX).^2*(h[2]*h[3]),
 #         DXZ    ZEROEY   -DZX;
 #        -DXY    DYX     ZEROEZ]
 
-T = spzeros(nfaces, nedges)
+T = spzeros(Tf, Tn, nfaces, nedges)
 T[nnz(FX)+1         : nnz(FX)+nnz(FY), 1 : nnz(EX)] =  DXZ
 T[nnz(FX)+nnz(FY)+1 : nfaces,          1 : nnz(EX)] = -DXY
 

--- a/src/getCurlMatrixRec.jl
+++ b/src/getCurlMatrixRec.jl
@@ -14,8 +14,9 @@ function getCurlMatrixRec(M)
 # [CURL,T,ESZ,FSZ] = getCurlMatrix(S)
 
 S = M.S; h = M.h
-Tn = eltype(S.SV.nzval)
-Tf = eltype(h)
+Tn  = eltype(S.SV.nzval)
+Tn2 = eltype(S.SV.nzind)
+Tf  = eltype(h)
 m1,m2,m3    = S.sz
 FX,FY,FZ, NFX,NFY,NFZ = getFaceSizeNumbering(M)
 EX,EY,EZ, NEX,NEY,NEZ = getEdgeSizeNumbering(M)
@@ -30,6 +31,7 @@ EX,EY,EZ, NEX,NEY,NEZ = getEdgeSizeNumbering(M)
 ######################################################################
 # look for y edges next to x faces
 i,j,k,fsz = find3(FX)
+fsz = convert(Vector{Tn2},fsz)
 fn        = nonzeros(NFX)
 
 ##
@@ -45,8 +47,8 @@ backmid  = zeros(Tn, length(back))
 
 I =  (j+div.(fsz,2) .<= m2) .& (fsz .>= 2)
 if any(I)
-  frontmid[I] = NEY.SV[sub2ind(NEY.sz, i[I] , j[I]+div.(fsz[I],2) , k[I]  )]
-  backmid[I]  = NEY.SV[sub2ind(NEY.sz, i[I] , j[I]+div.(fsz[I],2) , k[I]+fsz[I] )]
+  frontmid[I] = NEY.SV[sub2ind(NEY.sz, i[I] , j[I]+div.(fsz[I],Tn2(2)) , k[I]  )]
+  backmid[I]  = NEY.SV[sub2ind(NEY.sz, i[I] , j[I]+div.(fsz[I],Tn2(2)) , k[I]+fsz[I] )]
 end
 # front y
 
@@ -76,8 +78,8 @@ rightmid = zeros(Tn, length(right))
 
 I = (j+div.(fsz,2) .<= m2) .& (fsz .>= 2)
 if any(I)
-    leftmid[I]  = NEZ.SV[sub2ind(NEZ.sz, i[I], j[I],        k[I]+div.(fsz[I],2) )]
-    rightmid[I] = NEZ.SV[sub2ind(NEZ.sz, i[I], j[I]+fsz[I], k[I]+div.(fsz[I],2) )]
+    leftmid[I]  = NEZ.SV[sub2ind(NEZ.sz, i[I], j[I],        k[I]+div.(fsz[I],Tn2(2)) )]
+    rightmid[I] = NEZ.SV[sub2ind(NEZ.sz, i[I], j[I]+fsz[I], k[I]+div.(fsz[I],Tn2(2)) )]
 end
 Il1 = (leftmid .== 0)  # SINGLE LEFT EDGE PER FACE
 Il2 = (leftmid .>  0)  # 2 LEFT EDGES PER FACE
@@ -101,6 +103,7 @@ DZY = sparse(ii, jj, vv,nnz(NFX),nnz(NEZ))
 ######################################################################
 # look for y edges next to x faces
 i,j,k,fsz = find3(FY)
+fsz = convert(Vector{Tn2},fsz)
 fn        = nonzeros(NFY)
 
 
@@ -119,8 +122,8 @@ backmid  = zeros(Tn, length(back))
 
 I = (i+div.(fsz,2) .<= m1) .& (fsz .>= 2)
 if any(I)
-    frontmid[I] = NEX.SV[sub2ind(NEX.sz, i[I]+div.(fsz[I],2) , j[I] , k[I])]
-    backmid[I]  = NEX.SV[sub2ind(NEX.sz, i[I]+div.(fsz[I],2) , j[I] , k[I]+fsz[I])]
+    frontmid[I] = NEX.SV[sub2ind(NEX.sz, i[I]+div.(fsz[I],Tn2(2)) , j[I] , k[I])]
+    backmid[I]  = NEX.SV[sub2ind(NEX.sz, i[I]+div.(fsz[I],Tn2(2)) , j[I] , k[I]+fsz[I])]
 end
 
 If1 = (frontmid .== 0)  # SINGLE FRONT EDGE PER FACE
@@ -149,8 +152,8 @@ lowermid = zeros(Tn, length(lower))
 
 I = (i+div.(fsz,2) .<= m1) .& (fsz .>= 2)
 if any(I)
-    uppermid[I] = NEZ.SV[sub2ind(NEZ.sz, i[I], j[I], k[I]+div.(fsz[I],2) )]
-    lowermid[I] = NEZ.SV[sub2ind(NEZ.sz, i[I]+fsz[I] , j[I] , k[I]+div.(fsz[I],2) )]
+    uppermid[I] = NEZ.SV[sub2ind(NEZ.sz, i[I], j[I], k[I]+div.(fsz[I],Tn2(2)) )]
+    lowermid[I] = NEZ.SV[sub2ind(NEZ.sz, i[I]+fsz[I] , j[I] , k[I]+div.(fsz[I],Tn2(2)) )]
 end
 Iu1 = (uppermid .== 0)  # SINGLE UPPER EDGE PER FACE
 Iu2 = (uppermid .>  0)  # 2 UPPER EDGES PER FACE
@@ -172,6 +175,7 @@ DZX = sparse(ii, jj, vv,nnz(NFY),nnz(NEZ))
 ######################################################################
 # look for y edges next to x faces
 i,j,k,fsz = find3(FZ)
+fsz = convert(Vector{Tn2},fsz)
 fn        = nonzeros(NFZ)
 
 
@@ -190,8 +194,8 @@ rightmid = zeros(Tn, length(right))
 I = (i+div.(fsz,2) .<= m1) .& (fsz .>= 2)
 
 if any(I)
-    leftmid[I]  = NEX.SV[sub2ind(NEX.sz, i[I]+div.(fsz[I],2), j[I]        , k[I] )]
-    rightmid[I] = NEX.SV[sub2ind(NEX.sz, i[I]+div.(fsz[I],2), j[I]+fsz[I] , k[I] )]
+    leftmid[I]  = NEX.SV[sub2ind(NEX.sz, i[I]+div.(fsz[I],Tn2(2)), j[I]        , k[I] )]
+    rightmid[I] = NEX.SV[sub2ind(NEX.sz, i[I]+div.(fsz[I],Tn2(2)), j[I]+fsz[I] , k[I] )]
 end
 Il1 = (leftmid .== 0)  # SINGLE LEFT EDGE PER FACE
 Il2 = (leftmid .>  0)  # 2 LEFT EDGES PER FACE
@@ -218,8 +222,8 @@ lowermid = zeros(Tn, length(lower))
 
 I = (j+div.(fsz,2) .<= m2) .& (fsz .>= 2)
 if any(I)
-    uppermid[I] = NEY.SV[sub2ind(NEY.sz, i[I]        , j[I]+div.(fsz[I],2) , k[I] )]
-    lowermid[I] = NEY.SV[sub2ind(NEY.sz, i[I]+fsz[I] , j[I]+div.(fsz[I],2) , k[I] )]
+    uppermid[I] = NEY.SV[sub2ind(NEY.sz, i[I]        , j[I]+div.(fsz[I],Tn2(2)) , k[I] )]
+    lowermid[I] = NEY.SV[sub2ind(NEY.sz, i[I]+fsz[I] , j[I]+div.(fsz[I],Tn2(2)) , k[I] )]
 end
 Iu1 = (uppermid .== 0)  # SINGLE UPPER EDGE PER FACE
 Iu2 = (uppermid .>  0)  # 2 UPPER EDGES PER FACE

--- a/src/getDivergenceMatrixRec.jl
+++ b/src/getDivergenceMatrixRec.jl
@@ -45,8 +45,10 @@ function getDivergenceMatrixRec(S::SparseArray3D,h)
     FX,FY,FZ, FXN,FYN,FZN = getFaceSizeNumbering(S)
 	i,j,k,bsz    = find3(S)
     Tn           = eltype(bsz)
+    Tn2          = eltype(i)
     Tf           = eltype(h)
 	e1           = ones(Tf,length(i))
+    bsz          = convert(Vector{Tn2},bsz)
 	upper,lower,left,right,front,back = getNumberOfNeighbors(S)
 
 	#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -62,16 +64,16 @@ function getDivergenceMatrixRec(S::SparseArray3D,h)
     e  = ones(Tf,sum(I))
 
 	# mark 2nd, 3rd and 4th contributing upper faces
-    jj   = sub2ind(FXN.sz,i[I],j[I]+div.(bsz[I],2),k[I])
+    jj   = sub2ind(FXN.sz,i[I],j[I]+div.(bsz[I],Tn2(2)),k[I])
     iind = vec(full(CN.SV[ii[I]]))
     jind = vec(full(FXN.SV[jj]))
 	NX  += sparse(iind,jind,-e,nnz(CN),nnz(FXN))
 
-    jj   = sub2ind(FXN.sz,i[I],j[I],k[I]+div.(bsz[I],2))
+    jj   = sub2ind(FXN.sz,i[I],j[I],k[I]+div.(bsz[I],Tn2(2)))
     jind = vec(full(FXN.SV[jj]))
 	NX  += sparse(iind,jind,-e,nnz(CN),nnz(FXN))
 
-    jj   = sub2ind(FXN.sz,i[I],j[I]+div.(bsz[I],2),k[I]+div.(bsz[I],2))
+    jj   = sub2ind(FXN.sz,i[I],j[I]+div.(bsz[I],Tn2(2)),k[I]+div.(bsz[I],Tn2(2)))
     jind = vec(full(FXN.SV[jj]))
 	NX  += sparse(iind,jind,-e,nnz(CN),nnz(FXN))
 
@@ -86,16 +88,16 @@ function getDivergenceMatrixRec(S::SparseArray3D,h)
     e  = ones(Tf,sum(I))
 
 	# mark 2nd, 3rd and 4th contributing upper faces
-    jj   = sub2ind(FXN.sz,i[I]+bsz[I],j[I]+div.(bsz[I],2),k[I])
+    jj   = sub2ind(FXN.sz,i[I]+bsz[I],j[I]+div.(bsz[I],Tn2(2)),k[I])
     iind = vec(full(CN.SV[ii[I]]))
     jind = vec(full(FXN.SV[jj]))
 	NX  += sparse(iind,jind,e,nnz(CN),nnz(FXN))
 
-    jj   = sub2ind(FXN.sz,i[I]+bsz[I],j[I],k[I]+div.(bsz[I],2))
+    jj   = sub2ind(FXN.sz,i[I]+bsz[I],j[I],k[I]+div.(bsz[I],Tn2(2)))
     jind = vec(full(FXN.SV[jj]))
 	NX  += sparse(iind,jind,e,nnz(CN),nnz(FXN))
 
-    jj   = sub2ind(FXN.sz,i[I]+bsz[I],j[I]+div.(bsz[I],2),k[I]+div.(bsz[I],2))
+    jj   = sub2ind(FXN.sz,i[I]+bsz[I],j[I]+div.(bsz[I],Tn2(2)),k[I]+div.(bsz[I],Tn2(2)))
     jind = vec(full(FXN.SV[jj]))
 	NX  += sparse(iind,jind,e,nnz(CN),nnz(FXN))
 
@@ -117,16 +119,16 @@ function getDivergenceMatrixRec(S::SparseArray3D,h)
     e  = ones(Tf,sum(I))
 
 	# mark 2nd, 3rd and 4th contributing left faces
-    jj   = sub2ind(FYN.sz,i[I]+div.(bsz[I],2),j[I],k[I])
+    jj   = sub2ind(FYN.sz,i[I]+div.(bsz[I],Tn2(2)),j[I],k[I])
     iind = vec(full(CN.SV[ii[I]]))
     jind = vec(full(FYN.SV[jj]))
 	NY  += sparse(iind,jind,-e,nnz(CN),nnz(FYN))
 
-    jj   = sub2ind(FYN.sz,i[I],j[I],k[I]+div.(bsz[I],2))
+    jj   = sub2ind(FYN.sz,i[I],j[I],k[I]+div.(bsz[I],Tn2(2)))
     jind = vec(full(FYN.SV[jj]))
 	NY  += sparse(iind,jind,-e,nnz(CN),nnz(FYN))
 
-    jj   = sub2ind(FYN.sz,i[I]+div.(bsz[I],2),j[I],k[I]+div.(bsz[I],2))
+    jj   = sub2ind(FYN.sz,i[I]+div.(bsz[I],Tn2(2)),j[I],k[I]+div.(bsz[I],Tn2(2)))
     jind = vec(full(FYN.SV[jj]))
 	NY  += sparse(iind,jind,-e,nnz(CN),nnz(FYN))
 
@@ -136,16 +138,16 @@ function getDivergenceMatrixRec(S::SparseArray3D,h)
     e  = ones(Tf,sum(I))
 
 	# mark 2nd, 3rd and 4th contributing upper faces
-    jj   = sub2ind(FYN.sz,i[I]+div.(bsz[I],2),j[I]+bsz[I],k[I])
+    jj   = sub2ind(FYN.sz,i[I]+div.(bsz[I],Tn2(2)),j[I]+bsz[I],k[I])
     iind = vec(full(CN.SV[ii[I]]))
     jind = vec(full(FYN.SV[jj]))
  	NY  += sparse(iind,jind,e,nnz(CN),nnz(FYN))
 
-    jj   = sub2ind(FYN.sz,i[I],j[I]+bsz[I],k[I]+div.(bsz[I],2))
+    jj   = sub2ind(FYN.sz,i[I],j[I]+bsz[I],k[I]+div.(bsz[I],Tn2(2)))
     jind = vec(full(FYN.SV[jj]))
 	NY  += sparse(iind,jind,e,nnz(CN),nnz(FYN))
 
-    jj   = sub2ind(FYN.sz,i[I]+div.(bsz[I],2),j[I]+bsz[I],k[I]+div.(bsz[I],2))
+    jj   = sub2ind(FYN.sz,i[I]+div.(bsz[I],Tn2(2)),j[I]+bsz[I],k[I]+div.(bsz[I],Tn2(2)))
     jind = vec(full(FYN.SV[jj]))
 	NY  += sparse(iind,jind,e,nnz(CN),nnz(FYN))
 
@@ -166,16 +168,16 @@ function getDivergenceMatrixRec(S::SparseArray3D,h)
     e  = ones(Tf,sum(I))
 
 	# mark 2nd, 3rd and 4th contributing left faces
-    jj   = sub2ind(FZN.sz,i[I]+div.(bsz[I],2),j[I],k[I])
+    jj   = sub2ind(FZN.sz,i[I]+div.(bsz[I],Tn2(2)),j[I],k[I])
     iind = vec(full(CN.SV[ii[I]]))
     jind = vec(full(FZN.SV[jj]))
 	NZ  += sparse(iind,jind,-e,nnz(CN),nnz(FZN))
 
-    jj   = sub2ind(FZN.sz,i[I],j[I]+div.(bsz[I],2),k[I])
+    jj   = sub2ind(FZN.sz,i[I],j[I]+div.(bsz[I],Tn2(2)),k[I])
     jind = vec(full(FZN.SV[jj]))
 	NZ  += sparse(iind,jind,-e,nnz(CN),nnz(FZN))
 
-    jj   = sub2ind(FZN.sz,i[I]+div.(bsz[I],2),j[I]+div.(bsz[I],2),k[I])
+    jj   = sub2ind(FZN.sz,i[I]+div.(bsz[I],Tn2(2)),j[I]+div.(bsz[I],Tn2(2)),k[I])
     jind = vec(full(FZN.SV[jj]))
 	NZ  += sparse(iind,jind,-e,nnz(CN),nnz(FZN))
 
@@ -185,16 +187,16 @@ function getDivergenceMatrixRec(S::SparseArray3D,h)
     e  = ones(Tf,sum(I))
 
 	# mark 2nd, 3rd and 4th contributing upper faces
-    jj   = sub2ind(FZN.sz,i[I]+div.(bsz[I],2),j[I],k[I]+bsz[I])
+    jj   = sub2ind(FZN.sz,i[I]+div.(bsz[I],Tn2(2)),j[I],k[I]+bsz[I])
     iind = vec(full(CN.SV[ii[I]]))
     jind = vec(full(FZN.SV[jj]))
 	NZ  += sparse(iind,jind,e,nnz(CN),nnz(FZN))
 
-    jj   = sub2ind(FZN.sz,i[I],j[I]+div.(bsz[I],2),k[I]+bsz[I])
+    jj   = sub2ind(FZN.sz,i[I],j[I]+div.(bsz[I],Tn2(2)),k[I]+bsz[I])
     jind = vec(full(FZN.SV[jj]))
 	NZ  += sparse(iind,jind,e,nnz(CN),nnz(FZN))
 
-    jj   = sub2ind(FZN.sz,i[I]+div.(bsz[I],2),j[I]+div.(bsz[I],2),k[I]+bsz[I])
+    jj   = sub2ind(FZN.sz,i[I]+div.(bsz[I],Tn2(2)),j[I]+div.(bsz[I],Tn2(2)),k[I]+bsz[I])
     jind = vec(full(FZN.SV[jj]))
 	NZ  += sparse(iind,jind,e,nnz(CN),nnz(FZN))
 

--- a/src/getDivergenceMatrixRec.jl
+++ b/src/getDivergenceMatrixRec.jl
@@ -42,175 +42,176 @@ function getDivergenceMatrixRec(S::SparseArray3D,h)
 	# [DIV,N,HC,HF,NX,NY,NZ]=getDivergenceMatrixRec(S,h)
 
 	CN           = getCellNumbering(S)
-  FX,FY,FZ, FXN,FYN,FZN = getFaceSizeNumbering(S)
+    FX,FY,FZ, FXN,FYN,FZN = getFaceSizeNumbering(S)
 	i,j,k,bsz    = find3(S)
-	e1           = ones(length(i))
+    Tn           = eltype(bsz)
+    Tf           = eltype(h)
+	e1           = ones(Tf,length(i))
 	upper,lower,left,right,front,back = getNumberOfNeighbors(S)
 
 	#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	#%%% NORMALS ON X-FACES
 	#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  ii = sub2ind(CN.sz ,i,j,k)
+    ii   = sub2ind(CN.sz ,i,j,k)
+    jj   = sub2ind(FXN.sz,i,j,k)
+    iind = vec(full(CN.SV[ii]))
+    jind = vec(full(FXN.SV[jj]))
+	NX   = sparse(iind,jind,-e1,nnz(CN),nnz(FXN))
 
-  jj = sub2ind(FXN.sz,i,j,k)
-   iind = vec(full(CN.SV[ii]))
-   jind = vec(full(FXN.SV[jj]))
-	NX = sparse(iind,jind,-e1,nnz(CN),nnz(FXN))
-
-   I  = (upper .== 4)
-   e  = ones(Int64,sum(I))
+    I  = (upper .== 4)
+    e  = ones(Tf,sum(I))
 
 	# mark 2nd, 3rd and 4th contributing upper faces
-  jj = sub2ind(FXN.sz,i[I],j[I]+div.(bsz[I],2),k[I])
-   iind = vec(full(CN.SV[ii[I]]))
-   jind = vec(full(FXN.SV[jj]))
-	NX += sparse(iind,jind,-e,nnz(CN),nnz(FXN))
+    jj   = sub2ind(FXN.sz,i[I],j[I]+div.(bsz[I],2),k[I])
+    iind = vec(full(CN.SV[ii[I]]))
+    jind = vec(full(FXN.SV[jj]))
+	NX  += sparse(iind,jind,-e,nnz(CN),nnz(FXN))
 
-  jj = sub2ind(FXN.sz,i[I],j[I],k[I]+div.(bsz[I],2))
-   jind = vec(full(FXN.SV[jj]))
-	NX += sparse(iind,jind,-e,nnz(CN),nnz(FXN))
+    jj   = sub2ind(FXN.sz,i[I],j[I],k[I]+div.(bsz[I],2))
+    jind = vec(full(FXN.SV[jj]))
+	NX  += sparse(iind,jind,-e,nnz(CN),nnz(FXN))
 
-  jj = sub2ind(FXN.sz,i[I],j[I]+div.(bsz[I],2),k[I]+div.(bsz[I],2))
-   jind = vec(full(FXN.SV[jj]))
-	NX += sparse(iind,jind,-e,nnz(CN),nnz(FXN))
+    jj   = sub2ind(FXN.sz,i[I],j[I]+div.(bsz[I],2),k[I]+div.(bsz[I],2))
+    jind = vec(full(FXN.SV[jj]))
+	NX  += sparse(iind,jind,-e,nnz(CN),nnz(FXN))
 
 
 	# mark 2nd, 3rd and 4th contributing lower faces
-  jj = sub2ind(FXN.sz,i+bsz,j,k)
-   iind = vec(full(CN.SV[ii]))
-   jind = vec(full(FXN.SV[jj]))
-	NX += sparse(iind,jind,e1,nnz(CN),nnz(FXN))
+    jj   = sub2ind(FXN.sz,i+bsz,j,k)
+    iind = vec(full(CN.SV[ii]))
+    jind = vec(full(FXN.SV[jj]))
+	NX  += sparse(iind,jind,e1,nnz(CN),nnz(FXN))
 
-  I  = (lower .== 4)
-  e  = ones(Int64,sum(I))
+    I  = (lower .== 4)
+    e  = ones(Tf,sum(I))
 
 	# mark 2nd, 3rd and 4th contributing upper faces
-  jj = sub2ind(FXN.sz,i[I]+bsz[I],j[I]+div.(bsz[I],2),k[I])
-   iind = vec(full(CN.SV[ii[I]]))
-   jind = vec(full(FXN.SV[jj]))
-	NX += sparse(iind,jind,e,nnz(CN),nnz(FXN))
+    jj   = sub2ind(FXN.sz,i[I]+bsz[I],j[I]+div.(bsz[I],2),k[I])
+    iind = vec(full(CN.SV[ii[I]]))
+    jind = vec(full(FXN.SV[jj]))
+	NX  += sparse(iind,jind,e,nnz(CN),nnz(FXN))
 
-  jj = sub2ind(FXN.sz,i[I]+bsz[I],j[I],k[I]+div.(bsz[I],2))
-   jind = vec(full(FXN.SV[jj]))
-	NX += sparse(iind,jind,e,nnz(CN),nnz(FXN))
+    jj   = sub2ind(FXN.sz,i[I]+bsz[I],j[I],k[I]+div.(bsz[I],2))
+    jind = vec(full(FXN.SV[jj]))
+	NX  += sparse(iind,jind,e,nnz(CN),nnz(FXN))
 
-  jj = sub2ind(FXN.sz,i[I]+bsz[I],j[I]+div.(bsz[I],2),k[I]+div.(bsz[I],2))
-   jind = vec(full(FXN.SV[jj]))
-	NX += sparse(iind,jind,e,nnz(CN),nnz(FXN))
+    jj   = sub2ind(FXN.sz,i[I]+bsz[I],j[I]+div.(bsz[I],2),k[I]+div.(bsz[I],2))
+    jind = vec(full(FXN.SV[jj]))
+	NX  += sparse(iind,jind,e,nnz(CN),nnz(FXN))
 
 
 
 	#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	#%%%  NORMALS ON Y-FACES
 	#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  jj = sub2ind(FYN.sz,i,j,k)
-   iind = vec(full(CN.SV[ii]))
-   jind = vec(full(FYN.SV[jj]))
+    jj = sub2ind(FYN.sz,i,j,k)
+    iind = vec(full(CN.SV[ii]))
+    jind = vec(full(FYN.SV[jj]))
 	NY = sparse(iind,jind,-e1,nnz(CN),nnz(FYN))
 
-  jj = sub2ind(FYN.sz,i,j+bsz,k) 
-   jind = vec(full(FYN.SV[jj]))
+    jj = sub2ind(FYN.sz,i,j+bsz,k)
+    jind = vec(full(FYN.SV[jj]))
 	NY += sparse(iind,jind,e1,nnz(CN),nnz(FYN))
 
-  I  = (left .== 4)
-  e  = ones(Int64,sum(I))
+    I  = (left .== 4)
+    e  = ones(Tf,sum(I))
 
 	# mark 2nd, 3rd and 4th contributing left faces
-  jj = sub2ind(FYN.sz,i[I]+div.(bsz[I],2),j[I],k[I])
-   iind = vec(full(CN.SV[ii[I]]))
-   jind = vec(full(FYN.SV[jj]))
-	NY += sparse(iind,jind,-e,nnz(CN),nnz(FYN))
+    jj   = sub2ind(FYN.sz,i[I]+div.(bsz[I],2),j[I],k[I])
+    iind = vec(full(CN.SV[ii[I]]))
+    jind = vec(full(FYN.SV[jj]))
+	NY  += sparse(iind,jind,-e,nnz(CN),nnz(FYN))
 
-  jj = sub2ind(FYN.sz,i[I],j[I],k[I]+div.(bsz[I],2))
-   jind = vec(full(FYN.SV[jj]))
-	NY += sparse(iind,jind,-e,nnz(CN),nnz(FYN))
+    jj   = sub2ind(FYN.sz,i[I],j[I],k[I]+div.(bsz[I],2))
+    jind = vec(full(FYN.SV[jj]))
+	NY  += sparse(iind,jind,-e,nnz(CN),nnz(FYN))
 
-  jj = sub2ind(FYN.sz,i[I]+div.(bsz[I],2),j[I],k[I]+div.(bsz[I],2))
-   jind = vec(full(FYN.SV[jj]))
-	NY += sparse(iind,jind,-e,nnz(CN),nnz(FYN))
+    jj   = sub2ind(FYN.sz,i[I]+div.(bsz[I],2),j[I],k[I]+div.(bsz[I],2))
+    jind = vec(full(FYN.SV[jj]))
+	NY  += sparse(iind,jind,-e,nnz(CN),nnz(FYN))
 
 
 	# mark 2nd, 3rd and 4th contributing right faces
-  I  = (right .== 4)
-  e  = ones(Int64,sum(I))
+    I  = (right .== 4)
+    e  = ones(Tf,sum(I))
 
 	# mark 2nd, 3rd and 4th contributing upper faces
-  jj = sub2ind(FYN.sz,i[I]+div.(bsz[I],2),j[I]+bsz[I],k[I])
-   iind = vec(full(CN.SV[ii[I]]))
-   jind = vec(full(FYN.SV[jj]))
-	NY += sparse(iind,jind,e,nnz(CN),nnz(FYN))
+    jj   = sub2ind(FYN.sz,i[I]+div.(bsz[I],2),j[I]+bsz[I],k[I])
+    iind = vec(full(CN.SV[ii[I]]))
+    jind = vec(full(FYN.SV[jj]))
+ 	NY  += sparse(iind,jind,e,nnz(CN),nnz(FYN))
 
-  jj = sub2ind(FYN.sz,i[I],j[I]+bsz[I],k[I]+div.(bsz[I],2))
-   jind = vec(full(FYN.SV[jj]))
-	NY += sparse(iind,jind,e,nnz(CN),nnz(FYN))
+    jj   = sub2ind(FYN.sz,i[I],j[I]+bsz[I],k[I]+div.(bsz[I],2))
+    jind = vec(full(FYN.SV[jj]))
+	NY  += sparse(iind,jind,e,nnz(CN),nnz(FYN))
 
-  jj = sub2ind(FYN.sz,i[I]+div.(bsz[I],2),j[I]+bsz[I],k[I]+div.(bsz[I],2))
-   jind = vec(full(FYN.SV[jj]))
-	NY += sparse(iind,jind,e,nnz(CN),nnz(FYN))
+    jj   = sub2ind(FYN.sz,i[I]+div.(bsz[I],2),j[I]+bsz[I],k[I]+div.(bsz[I],2))
+    jind = vec(full(FYN.SV[jj]))
+	NY  += sparse(iind,jind,e,nnz(CN),nnz(FYN))
 
 
 	#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	#%%%%  NORMALS ON Z-FACES
 	#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-  jj = sub2ind(FZN.sz,i,j,k)
-   iind = vec(full(CN.SV[ii]))
-   jind = vec(full(FZN.SV[jj]))
-	NZ = sparse(iind,jind,-e1,nnz(CN),nnz(FZN))
+    jj   = sub2ind(FZN.sz,i,j,k)
+    iind = vec(full(CN.SV[ii]))
+    jind = vec(full(FZN.SV[jj]))
+    NZ   = sparse(iind,jind,-e1,nnz(CN),nnz(FZN))
 
-  jj = sub2ind(FZN.sz,i,j,k+bsz)
-   jind = vec(full(FZN.SV[jj]))
-	NZ += sparse(iind,jind,e1,nnz(CN),nnz(FZN))
+    jj   = sub2ind(FZN.sz,i,j,k+bsz)
+    jind = vec(full(FZN.SV[jj]))
+	NZ  += sparse(iind,jind,e1,nnz(CN),nnz(FZN))
 
-  I  = (front .== 4)
-  e  = ones(Int64,sum(I))
+    I  = (front .== 4)
+    e  = ones(Tf,sum(I))
 
 	# mark 2nd, 3rd and 4th contributing left faces
-  jj = sub2ind(FZN.sz,i[I]+div.(bsz[I],2),j[I],k[I])
-   iind = vec(full(CN.SV[ii[I]]))
-   jind = vec(full(FZN.SV[jj]))
-	NZ += sparse(iind,jind,-e,nnz(CN),nnz(FZN))
+    jj   = sub2ind(FZN.sz,i[I]+div.(bsz[I],2),j[I],k[I])
+    iind = vec(full(CN.SV[ii[I]]))
+    jind = vec(full(FZN.SV[jj]))
+	NZ  += sparse(iind,jind,-e,nnz(CN),nnz(FZN))
 
-  jj = sub2ind(FZN.sz,i[I],j[I]+div.(bsz[I],2),k[I])
-   jind = vec(full(FZN.SV[jj]))
-	NZ += sparse(iind,jind,-e,nnz(CN),nnz(FZN))
+    jj   = sub2ind(FZN.sz,i[I],j[I]+div.(bsz[I],2),k[I])
+    jind = vec(full(FZN.SV[jj]))
+	NZ  += sparse(iind,jind,-e,nnz(CN),nnz(FZN))
 
-  jj = sub2ind(FZN.sz,i[I]+div.(bsz[I],2),j[I]+div.(bsz[I],2),k[I])
-   jind = vec(full(FZN.SV[jj]))
-	NZ += sparse(iind,jind,-e,nnz(CN),nnz(FZN))
+    jj   = sub2ind(FZN.sz,i[I]+div.(bsz[I],2),j[I]+div.(bsz[I],2),k[I])
+    jind = vec(full(FZN.SV[jj]))
+	NZ  += sparse(iind,jind,-e,nnz(CN),nnz(FZN))
 
 
 	# mark 2nd, 3rd and 4th contributing right faces
-  I  = (back .== 4)
-  e  = ones(Int64,sum(I))
+    I  = (back .== 4)
+    e  = ones(Tf,sum(I))
 
 	# mark 2nd, 3rd and 4th contributing upper faces
-  jj = sub2ind(FZN.sz,i[I]+div.(bsz[I],2),j[I],k[I]+bsz[I])
-   iind = vec(full(CN.SV[ii[I]]))
-   jind = vec(full(FZN.SV[jj]))
-	NZ += sparse(iind,jind,e,nnz(CN),nnz(FZN))
+    jj   = sub2ind(FZN.sz,i[I]+div.(bsz[I],2),j[I],k[I]+bsz[I])
+    iind = vec(full(CN.SV[ii[I]]))
+    jind = vec(full(FZN.SV[jj]))
+	NZ  += sparse(iind,jind,e,nnz(CN),nnz(FZN))
 
-  jj = sub2ind(FZN.sz,i[I],j[I]+div.(bsz[I],2),k[I]+bsz[I])
-   jind = vec(full(FZN.SV[jj]))
-	NZ += sparse(iind,jind,e,nnz(CN),nnz(FZN))
+    jj   = sub2ind(FZN.sz,i[I],j[I]+div.(bsz[I],2),k[I]+bsz[I])
+    jind = vec(full(FZN.SV[jj]))
+	NZ  += sparse(iind,jind,e,nnz(CN),nnz(FZN))
 
-  jj = sub2ind(FZN.sz,i[I]+div.(bsz[I],2),j[I]+div.(bsz[I],2),k[I]+bsz[I])
-   jind = vec(full(FZN.SV[jj]))
-	NZ += sparse(iind,jind,e,nnz(CN),nnz(FZN))
+    jj   = sub2ind(FZN.sz,i[I]+div.(bsz[I],2),j[I]+div.(bsz[I],2),k[I]+bsz[I])
+    jind = vec(full(FZN.SV[jj]))
+	NZ  += sparse(iind,jind,e,nnz(CN),nnz(FZN))
 
-  nrow = size(NX,1)
-  nc1 = size(NX,2)
-  nc2 = size(NY,2)
-  nc3 = size(NZ,2)
-  N = spzeros(nrow, nc1+nc2+nc3)
-  N[:, 1:nc1] = NX
-  N[:, nc1+1:nc1+nc2] = NY
-  N[:, nc1+nc2+1:nc1+nc2+nc3] = NZ
+    nrow = size(NX,1)
+    nc1  = size(NX,2)
+    nc2  = size(NY,2)
+    nc3  = size(NZ,2)
+    N    = spzeros(Tf, Tn, nrow, nc1+nc2+nc3)
+    N[:, 1:nc1] = NX
+    N[:, nc1+1:nc1+nc2] = NY
+    N[:, nc1+nc2+1:nc1+nc2+nc3] = NZ
 
-  CSZi = 1. ./ (nonzeros(S).^3*prod(h))
+    CSZi = one(Tf) ./ (nonzeros(S).^3*prod(h))
 
-  FSZ = vcat(nonzeros(FX).^2*(h[2]*h[3]),
-             nonzeros(FY).^2*(h[1]*h[3]),
-             nonzeros(FZ).^2*(h[1]*h[2]) )
+    FSZ  = vcat(nonzeros(FX).^2*(h[2]*h[3]),
+                nonzeros(FY).^2*(h[1]*h[3]),
+                nonzeros(FZ).^2*(h[1]*h[2]) )
 
    DIV = DiagTimesMTimesDiag!(CSZi, N, FSZ)
 

--- a/src/getEdgeConstraints.jl
+++ b/src/getEdgeConstraints.jl
@@ -30,12 +30,14 @@ function getEdgeConstraints(::Type{Tf},S::SparseArray3D) where Tf
 #
 
 i0,j0,k0,bsz = find3(S)
+Tn2 = eltype(i0)
+bsz = convert(Vector{Tn2},bsz)
 
-i1 = i0 + div.(bsz, 2)
+i1 = i0 + div.(bsz, Tn2(2))
 i2 = i0 + bsz
-j1 = j0 + div.(bsz, 2)
+j1 = j0 + div.(bsz, Tn2(2))
 j2 = j0 + bsz
-k1 = k0 + div.(bsz, 2)
+k1 = k0 + div.(bsz, Tn2(2))
 k2 = k0 + bsz
 
 upper,lower,left,right,front,back = getNumberOfNeighbors(S)

--- a/src/getEdgeConstraints.jl
+++ b/src/getEdgeConstraints.jl
@@ -2,18 +2,20 @@ export getEdgeConstraints
 
 function getEdgeConstraints(M::OcTreeMesh)
 	if isempty(M.Ne)
+		T = eltype(M.h)
 		if all(M.S.SV.nzval.==M.S.SV.nzval[1]) # uniform mesh
-			M.Ne = speye(sum(M.ne))
-			M.Qe = speye(sum(M.ne))
-                        M.activeEdges = [1:sum(M.ne);]
+			N = typeof(M.nc)
+			M.Ne = speye(T,N,sum(M.ne))
+			M.Qe = speye(T,N,sum(M.ne))
+            M.activeEdges = collect(N,1:sum(M.ne))
 		else
-			M.Ne,M.Qe, Ce, M.activeEdges = getEdgeConstraints(M.S)
+			M.Ne,M.Qe, Ce, M.activeEdges = getEdgeConstraints(T,M.S)
 		end
 	end
 	return M.Ne,M.Qe, M.activeEdges
 end
 
-function getEdgeConstraints(S::SparseArray3D)
+function getEdgeConstraints(::Type{Tf},S::SparseArray3D) where Tf
 # N,Q,C,p = getEdgeConstraints
 # Eliminates the hanging edges
 #   C ... constraint matrix
@@ -43,9 +45,10 @@ if ~all( (nn .== 0) .| (nn .== 1) .| (nn .== 4) )
 end
 ENX,ENY,ENZ = getEdgeNumbering(S)
 
-ex1 = Int64[]; ex2 = Int64[]; ex3 = Int64[]; ex4 = Int64[]; ex5 = Int64[]; ex6 = Int64[];
-ey1 = Int64[]; ey2 = Int64[]; ey3 = Int64[]; ey4 = Int64[]; ey5 = Int64[]; ey6 = Int64[];
-ez1 = Int64[]; ez2 = Int64[]; ez3 = Int64[]; ez4 = Int64[]; ez5 = Int64[]; ez6 = Int64[];
+Tn  = eltype(ENX.SV.nzval)
+ex1 = Tn[]; ex2 = Tn[]; ex3 = Tn[]; ex4 = Tn[]; ex5 = Tn[]; ex6 = Tn[];
+ey1 = Tn[]; ey2 = Tn[]; ey3 = Tn[]; ey4 = Tn[]; ey5 = Tn[]; ey6 = Tn[];
+ez1 = Tn[]; ez2 = Tn[]; ez3 = Tn[]; ez4 = Tn[]; ez5 = Tn[]; ez6 = Tn[];
 
 
 #    ^ k z
@@ -189,10 +192,11 @@ ez1 = vec(ez1); ez2 = vec(ez2); ez3 = vec(ez3)
 ez4 = vec(ez4); ez5 = vec(ez5); ez6 = vec(ez6)
 
 #e7 are the edges neither in e1, e2, e3, e4, e5 or e6
-nx = nnz(ENX); ny = nnz(ENY);  nz = nnz(ENZ)
-ex7 = setdiff([1:nx;], [ex1; ex2; ex3; ex4; ex5; ex6])
-ey7 = setdiff([1:ny;], [ey1; ey2; ey3; ey4; ey5; ey6])
-ez7 = setdiff([1:nz;], [ez1; ez2; ez3; ez4; ez5; ez6])
+nx  = Tn(nnz(ENX)); ny = Tn(nnz(ENY));  nz = Tn(nnz(ENZ))
+Tn1 = one(Tn)
+ex7 = setdiff([Tn1:nx;], [ex1; ex2; ex3; ex4; ex5; ex6])
+ey7 = setdiff([Tn1:ny;], [ey1; ey2; ey3; ey4; ey5; ey6])
+ez7 = setdiff([Tn1:nz;], [ez1; ez2; ez3; ez4; ez5; ez6])
 
 # look up table for new edge numbering
 bx = falses(nx)
@@ -208,10 +212,10 @@ mx = sum(bx);
 my = sum(by);
 mz = sum(bz);
 
-px = zeros(Int64,nx)
-py = zeros(Int64,ny)
-pz = zeros(Int64,nz)
-p  = zeros(Int64,nx+ny+nz)
+px = zeros(Tn,nx)
+py = zeros(Tn,ny)
+pz = zeros(Tn,nz)
+p  = zeros(Tn,nx+ny+nz)
 
 px[bx] = 1:mx;
 py[by] = 1:my;
@@ -239,67 +243,64 @@ p[b]   = 1:mx+my+mz;
 #    e4 I/2  I/2
 
 
-## X edges
-
+# X edges
 # remove duplicates in [ex1; ex5]
-I    = speye(nx)
 ex15 = [ex1; ex5]
 ex26 = [ex2; ex6]
 ex15 = unique(ex15)
 i15  = indexin(ex15,[ex1;ex5])
 ex26 = ex26[i15]
 
-k  = length(ex15)
-m  = length(ex1)
-n  = length(ex7)
+k  = Tn(length(ex15))
+m  = Tn(length(ex1))
+n  = Tn(length(ex7))
 
 # constraint matrix
-i  = [1:k; k+(1:2*m); k+(1:2*m); 1:k; k+(1:2*m)]
+i  = [Tn1:k; k+(Tn1:Tn(2*m)); k+(Tn1:Tn(2*m)); Tn1:k; k+(Tn1:Tn(2*m))]
 j  = [ex15; ex1; ex1; ex5; ex5; ex26; ex3; ex4]
-v  = [ones(k); 0.5*ones(4*m); -ones(k+2*m)]
+v  = [ones(Tf,k); 0.5*ones(Tf,4*m); -ones(Tf,k+2*m)]
 Cx = sparse(i,j,v,k+2*m,nx)
 
 # null space matrix
 i  = [ex15; ex26; ex3; ex4; ex3; ex4; ex7]
 j  = px[[ex15; ex15; ex1; ex1; ex5; ex5; ex7]]
-v  = [ones(2*k); 0.5*ones(4*m); ones(n)]
+v  = [ones(Tf,2*k); 0.5*ones(Tf,4*m); ones(Tf,n)]
 Nx = sparse(i,j,v,nx,mx)
 
 # projection matrix
 i  = px[[ex15; ex7; ex15]]
 j  = [ex15; ex7; ex26];
-v  = [0.5*ones(k); ones(n); 0.5*ones(k)]
+v  = [0.5*ones(Tf,k); ones(Tf,n); 0.5*ones(Tf,k)]
 Qx = sparse(i,j,v,mx,nx)
 
 # Y edges
 # remove duplicates in [ey1; ey5]
-I    = speye(ny)
 ey15 = [ey1; ey5];
 ey26 = [ey2; ey6];
 ey15 = unique(ey15);
 i15  = indexin(ey15,[ey1;ey5])
 ey26 = ey26[i15]
 
-k  = length(ey15);
-m  = length(ey1);
-n  = length(ey7);
+k  = Tn(length(ey15))
+m  = Tn(length(ey1))
+n  = Tn(length(ey7))
 
 # constraint matrix
-i  = [1:k; k+(1:2*m); k+(1:2*m); 1:k; k+(1:2*m)]
+i  = [Tn1:k; k+(Tn1:Tn(2*m)); k+(Tn1:Tn(2*m)); Tn1:k; k+(Tn1:Tn(2*m))]
 j  = [ey15; ey1; ey1; ey5; ey5; ey26; ey3; ey4]
-v  = [ones(k); 0.5*ones(4*m); -ones(k+2*m)]
+v  = [ones(Tf,k); 0.5*ones(Tf,4*m); -ones(Tf,k+2*m)]
 Cy = sparse(i,j,v,k+2*m,ny)
 
 # null space matrix
 i  = [ey15; ey26; ey3; ey4; ey3; ey4; ey7]
 j  = py[[ey15; ey15; ey1; ey1; ey5; ey5; ey7]]
-v  = [ones(2*k); 0.5*ones(4*m); ones(n)]
+v  = [ones(Tf,2*k); 0.5*ones(Tf,4*m); ones(Tf,n)]
 Ny = sparse(i,j,v,ny,my)
 
 # projection matrix
 i  = py[[ey15; ey7; ey15]]
 j  = [ey15; ey7; ey26]
-v  = [0.5*ones(k); ones(n); 0.5*ones(k)]
+v  = [0.5*ones(Tf,k); ones(Tf,n); 0.5*ones(Tf,k)]
 Qy = sparse(i,j,v,my,ny)
 
 ## Z edges
@@ -310,26 +311,26 @@ ez15 = unique(ez15);
 i15  = indexin(ez15,[ez1;ez5])
 ez26 = ez26[i15]
 
-k  = length(ez15);
-m  = length(ez1);
-n  = length(ez7);
+k  = Tn(length(ez15))
+m  = Tn(length(ez1))
+n  = Tn(length(ez7))
 
 # constraint matrix
-i  = [1:k; k+(1:2*m); k+(1:2*m); 1:k; k+(1:2*m)]
+i  = [Tn1:k; k+(Tn1:Tn(2*m)); k+(Tn1:Tn(2*m)); Tn1:k; k+(Tn1:Tn(2*m))]
 j  = [ez15; ez1; ez1; ez5; ez5; ez26; ez3; ez4]
-v  = [ones(k); 0.5*ones(4*m); -ones(k+2*m)]
+v  = [ones(Tf,k); 0.5*ones(Tf,4*m); -ones(Tf,k+2*m)]
 Cz = sparse(i,j,v,k+2*m,nz)
 
 # null space matrix
-i  = [ez15; ez26; ez3; ez4; ez3; ez4; ez7];
+i  = [ez15; ez26; ez3; ez4; ez3; ez4; ez7]
 j  = pz[[ez15; ez15; ez1; ez1; ez5; ez5; ez7]]
-v  = [ones(2*k); 0.5*ones(4*m); ones(n)]
+v  = [ones(Tf,2*k); 0.5*ones(Tf,4*m); ones(Tf,n)]
 Nz = sparse(i,j,v,nz,mz)
 
 # projection matrix
 i  = pz[[ez15; ez7; ez15]]
 j  = [ez15; ez7; ez26];
-v  = [0.5*ones(k); ones(n); 0.5*ones(k)]
+v  = [0.5*ones(Tf,k); ones(Tf,n); 0.5*ones(Tf,k)]
 Qz = sparse(i,j,v,mz,nz)
 
 ## Put it all together

--- a/src/getEdgeIntegralOfPolygonalChain.jl
+++ b/src/getEdgeIntegralOfPolygonalChain.jl
@@ -2,7 +2,7 @@ export getEdgeIntegralOfPolygonalChain
 
 using Base.BLAS
 
-function getEdgeIntegralOfPolygonalChain(mesh::OcTreeMesh, polygon::Array{Float64,2}; normalize=false)
+function getEdgeIntegralOfPolygonalChain(mesh::OcTreeMesh, polygon::Array{Tf,2}; normalize=false) where Tf <: Real
 # s = getEdgeIntegralPolygonalChain(mesh,polygon)
 # s = getEdgeIntegralPolygonalChain(mesh,polygon,normalize)
 #
@@ -120,15 +120,16 @@ z = float([1:nz+1;])
 nnX = nnz(EX)
 nnY = nnz(EY)
 nnZ = nnz(EZ)
-ss = spzeros(nnX+nnY+nnZ,1)
+Tn  = eltype(EX.SV.nzval)
+ss  = spzeros(Tf,Tn,nnX+nnY+nnZ,1)
 
 # allocate local variables
-sxloc = zeros(4)
-syloc = zeros(4)
-szloc = zeros(4)
-kx    = zeros(Int64,4)
-ky    = zeros(Int64,4)
-kz    = zeros(Int64,4)
+sxloc = zeros(Tf,4)
+syloc = zeros(Tf,4)
+szloc = zeros(Tf,4)
+kx    = zeros(Tn,4)
+ky    = zeros(Tn,4)
+kz    = zeros(Tn,4)
 tol   = 0.0
 
 # integrate each line segment

--- a/src/getEdgeInterpolationMatrix.jl
+++ b/src/getEdgeInterpolationMatrix.jl
@@ -1,43 +1,44 @@
 export getEdgeInterpolationMatrix
 
-function getEdgeInterpolationMatrix(mesh::OcTreeMesh, x::Array{Float64,1}, y::Array{Float64,1}, z::Array{Float64,1})
-	
+function getEdgeInterpolationMatrix(mesh::OcTreeMesh, x::Array{Tf,1}, y::Array{Tf,1}, z::Array{Tf,1}) where Tf <: Real
+
 	# map interpolation points to OcTree integer space
 	x = (x - mesh.x0[1]) / mesh.h[1] + 1.0
 	y = (y - mesh.x0[2]) / mesh.h[2] + 1.0
 	z = (z - mesh.x0[3]) / mesh.h[3] + 1.0
-	
+
 	# interpolation point numbers
-	n = length(x)
-	P = repmat([1:n;],4)
-	
+    Tn = typeof(mesh.nc)
+	n  = Tn(length(x))
+	P  = repmat([one(Tn):n;],4)
+
 	# get edge enumeration
 	Ex,Ey,Ez = getEdgeNumbering(mesh.S)
 	nx = nnz(Ex)
 	ny = nnz(Ey)
 	nz = nnz(Ez)
-	
+
 	# locate points within cells
 	i,j,k,bsz = findBlocks(mesh.S, floor(Integer,x), floor(Integer,y), floor(Integer,z))
-	
-	# x-edge numbers 
+
+	# x-edge numbers
 	I  = [i, i, i, i;]
 	J  = [j, j+bsz, j, j+bsz;]
 	K  = [k, k, k+bsz, k+bsz;]
 	Ex = vec(full(Ex.SV[sub2ind(size(Ex), I, J, K)]))
-	
-	# y-edge numbers 
+
+	# y-edge numbers
 	I  = [i, i+bsz, i, i+bsz;]
 	J  = [j, j, j, j;]
 	K  = [k, k, k+bsz, k+bsz;]
 	Ey = vec(full(Ey.SV[sub2ind(size(Ey), I, J, K)]))
-	
-	# z-edge numbers 
+
+	# z-edge numbers
 	I  = [i, i+bsz, i, i+bsz;]
 	J  = [j, j, j+bsz, j+bsz;]
 	K  = [k, k, k, k;]
 	Ez = vec(full(Ez.SV[sub2ind(size(Ez), I, J, K)]))
-	
+
 	# linear basis
 	u2 = (x - i) ./ bsz
 	u1 = 1.0 - u2
@@ -45,17 +46,17 @@ function getEdgeInterpolationMatrix(mesh::OcTreeMesh, x::Array{Float64,1}, y::Ar
 	v1 = 1.0 - v2
 	w2 = (z - k) ./ bsz
 	w1 = 1.0 - w2
-	
+
 	# bilinear interpolation
 	Qx = [v1 .* w1, v2 .* w1, v1 .* w2, v2 .* w2;] # constant along x
 	Qy = [u1 .* w1, u2 .* w1, u1 .* w2, u2 .* w2;] # constant along y
 	Qz = [u1 .* v1, u2 .* v1, u1 .* v2, u2 .* v2;] # constant along z
-	
+
 	# assemble sparse interpolation matrices
 	Qx = sparse(P, Ex, Qx, n, nx)
 	Qy = sparse(P, Ey, Qy, n, ny)
 	Qz = sparse(P, Ez, Qz, n, nz)
 
 	return Qx,Qy,Qz
-	
+
 end

--- a/src/getEdgeMassMatrix.jl
+++ b/src/getEdgeMassMatrix.jl
@@ -61,7 +61,8 @@ function getdEdgeMassMatrix{T<:Number}(mesh::OcTreeMeshFV, sigma::Vector, v::Vec
         dM = SparseMatrixCSC(P.A.m, P.A.n, copy(P.A.colptr), copy(P.A.rowval), T.(P.A.nzval))
         DiagTimesM(v, dM)
     else # generally anisotropic
-        V = SparseMatrixCSC(P.n, nz, collect(eltype(P.A.colptr),1:nz+1), P.rowval, v[P.colval])
+        N = eltype(P.A.colptr)
+        V = SparseMatrixCSC(P.n, nz, collect(N,1:nz+1), P.rowval, v[P.colval])
         dM = V * P.A
     end
     return dM
@@ -149,8 +150,8 @@ for isotropic, diagonally anisotropic or generally anisotropic coefficient.
 function setupEdgeMassMatrix(mesh::OcTreeMeshFV, sigma)
 
     na = length(sigma)
-    N  = typeof(mesh.nc)
-    nc = N(mesh.nc)
+    nc = mesh.nc
+    N  = typeof(nc)
 
     @assert in(na, [nc, 3*nc, 6*nc]) "Invalid size of sigma"
 

--- a/src/getEdgeMassMatrix.jl
+++ b/src/getEdgeMassMatrix.jl
@@ -61,7 +61,7 @@ function getdEdgeMassMatrix{T<:Number}(mesh::OcTreeMeshFV, sigma::Vector, v::Vec
         dM = SparseMatrixCSC(P.A.m, P.A.n, copy(P.A.colptr), copy(P.A.rowval), T.(P.A.nzval))
         DiagTimesM(v, dM)
     else # generally anisotropic
-        V = SparseMatrixCSC(P.n, nz, collect(1:nz+1), P.rowval, v[P.colval])
+        V = SparseMatrixCSC(P.n, nz, collect(eltype(P.A.colptr),1:nz+1), P.rowval, v[P.colval])
         dM = V * P.A
     end
     return dM
@@ -97,7 +97,7 @@ function dEdgeMassMatrixTimesVector{T<:Number}(mesh::OcTreeMeshFV, sigma::Vector
         dMx = T.(P.A * x)
         dMx .*= v
     else # generally anisotropic
-        V = SparseMatrixCSC(P.n, nz, collect(1:nz+1), P.rowval, v[P.colval])
+        V = SparseMatrixCSC(P.n, nz, collect(eltype(P.rowval),1:nz+1), P.rowval, v[P.colval])
         dMx = V * (P.A * x)
     end
     return dMx
@@ -131,7 +131,7 @@ function dEdgeMassMatrixTrTimesVector{T<:Number}(mesh::OcTreeMeshFV, sigma::Vect
         u = conj.(v) .* x
         dMTx = P.A' * u
     else # generally anisotropic
-        V = SparseMatrixCSC(P.n, nz, collect(1:nz+1), P.rowval, v[P.colval])
+        V = SparseMatrixCSC(P.n, nz, collect(eltype(P.rowval),1:nz+1), P.rowval, v[P.colval])
         u = V' * x
         dMTx = P.A' * u
     end
@@ -146,10 +146,11 @@ end
 Precompute and return stored data structure for edge mass matrix integration
 for isotropic, diagonally anisotropic or generally anisotropic coefficient.
 """
-function setupEdgeMassMatrix(mesh, sigma)
+function setupEdgeMassMatrix(mesh::OcTreeMeshFV, sigma)
 
     na = length(sigma)
-    nc = mesh.nc
+    N  = typeof(mesh.nc)
+    nc = N(mesh.nc)
 
     @assert in(na, [nc, 3*nc, 6*nc]) "Invalid size of sigma"
 
@@ -161,24 +162,24 @@ function setupEdgeMassMatrix(mesh, sigma)
         if na == nc
 
             i = vcat(ex, ey, ez)
-            j = repmat(1:nc, 24)
+            j = repmat(one(N):nc, 24)
             a = repmat(w, 24)
             A = sparse(i, j, a, n, na)
-            colptr = collect(1:n+1)
-            rowval = collect(1:n)
-            colval = Array{Int64}(0) # unused
+            colptr = collect(N,1:n+1)
+            rowval = collect(N,1:n)
+            colval = Array{N}(0) # unused
 
         elseif na == 3 * nc
 
             i = vcat(ex, ey, ez)
-            j = vcat(repmat(     1:  nc, 8),
-                     repmat(  nc+1:2*nc, 8),
-                     repmat(2*nc+1:3*nc, 8))
+            j = vcat(repmat(UnitRange{N}(     1:nc  ), 8),
+                     repmat(UnitRange{N}(  nc+1:2*nc), 8),
+                     repmat(UnitRange{N}(2*nc+1:3*nc), 8))
             a = repmat(w, 24)
             A = sparse(i, j, a, n, na)
-            colptr = collect(1:n+1)
-            rowval = collect(1:n)
-            colval = Array{Int64}(0) # unused
+            colptr = collect(N,1:n+1)
+            rowval = collect(N,1:n)
+            colval = Array{N}(0) # unused
 
         elseif na == 6 * nc
 
@@ -200,15 +201,15 @@ function setupEdgeMassMatrix(mesh, sigma)
 
             # construct mapping of anisotropic cell property to
             # nonzero entries in mass matrix
-            j = vcat(repmat(     1:  nc, 8),
-                     repmat(  nc+1:2*nc, 8),
-                     repmat(2*nc+1:3*nc, 8),
-                     repmat(3*nc+1:4*nc, 8),
-                     repmat(4*nc+1:5*nc, 8),
-                     repmat(5*nc+1:6*nc, 8),
-                     repmat(3*nc+1:4*nc, 8),
-                     repmat(4*nc+1:5*nc, 8),
-                     repmat(5*nc+1:6*nc, 8))
+            j = vcat(repmat(UnitRange{N}(     1:  nc), 8),
+                     repmat(UnitRange{N}(  nc+1:2*nc), 8),
+                     repmat(UnitRange{N}(2*nc+1:3*nc), 8),
+                     repmat(UnitRange{N}(3*nc+1:4*nc), 8),
+                     repmat(UnitRange{N}(4*nc+1:5*nc), 8),
+                     repmat(UnitRange{N}(5*nc+1:6*nc), 8),
+                     repmat(UnitRange{N}(3*nc+1:4*nc), 8),
+                     repmat(UnitRange{N}(4*nc+1:5*nc), 8),
+                     repmat(UnitRange{N}(5*nc+1:6*nc), 8))
             a = repmat(w, 72)
             A = sparse(i, j, a, nz, na)
 
@@ -230,7 +231,7 @@ Compute quadrature points and weights for integration of edge mass matrix.
 `getEdgeMassMatrixQuadrature` returns a list of edges and weights
 for eight quadrature points, the corners of each cell.
 """
-function getEdgeMassMatrixQuadrature(mesh)
+function getEdgeMassMatrixQuadrature(mesh::OcTreeMeshFV)
 
 # To illustrate the integration, consider the 2D case (QuadTree) and, in
 # particular, the cell C1 of size 2 * h which has two right neighbors of

--- a/src/getEdgeToCellCenteredMatrix.jl
+++ b/src/getEdgeToCellCenteredMatrix.jl
@@ -41,10 +41,11 @@ Pz2 = ez.SV[sub2ind(nez,i+bsz,j,k),1]
 Pz3 = ez.SV[sub2ind(nez,i,j+bsz,k),1]
 Pz4 = ez.SV[sub2ind(nez,i+bsz,j+bsz,k),1]
 
-
-sp1(Q) = sparse(1:Base.nnz(Q),Base.nonzeros(Q),ones(Base.nnz(Q)),nc,nx)
-sp2(Q) = sparse(1:Base.nnz(Q),Base.nonzeros(Q),ones(Base.nnz(Q)),nc,ny)
-sp3(Q) = sparse(1:Base.nnz(Q),Base.nonzeros(Q),ones(Base.nnz(Q)),nc,nz)
+Tn = eltype(S.SV.nzval)
+Tn1 = one(Tn)
+sp1(Q) = sparse(Tn1:Tn(Base.nnz(Q)),Tn(Base.nonzeros(Q)),ones(Base.nnz(Q)),nc,nx)
+sp2(Q) = sparse(Tn1:Tn(Base.nnz(Q)),Tn(Base.nonzeros(Q)),ones(Base.nnz(Q)),nc,ny)
+sp3(Q) = sparse(Tn1:Tn(Base.nnz(Q)),Tn(Base.nonzeros(Q)),ones(Base.nnz(Q)),nc,nz)
 
 Ax = 1/4 * (sp1(Px1) + sp1(Px2) + sp1(Px3) + sp1(Px4))
 Ay = 1/4 * (sp2(Py1) + sp2(Py2) + sp2(Py3) + sp2(Py4))

--- a/src/getEdgeToCellCenteredMatrix.jl
+++ b/src/getEdgeToCellCenteredMatrix.jl
@@ -14,9 +14,9 @@ function getEdgeToCellCenteredMatrix(S::SparseArray3D)
 #
 
 n   = S.sz;
-nex = n + [0, 1, 1]
-ney = n + [1, 0, 1]
-nez = n + [1, 1, 0]
+nex = (n[1],n[2]+1,n[3]+1)
+ney = (n[1]+1,n[2],n[3]+1)
+nez = (n[1]+1,n[2]+1,n[3])
 
 i,j,k,bsz = find3(S)
 ex,ey,ez = getEdgeNumbering(S)

--- a/src/getFaceConstraints.jl
+++ b/src/getFaceConstraints.jl
@@ -25,13 +25,15 @@ function getFaceConstraints(::Type{Tf},S::SparseArray3D) where Tf
     #   p ............... lookup table for new face enumeration:
     #                     new face number = p(old face number)
     #                     (returns zero for deleted faces)
-    i0,j0,k0,bsz = find3(S);
+    i0,j0,k0,bsz = find3(S)
+	Tn2 = eltype(i0)
+	bsz = convert(Vector{Tn2},bsz)
 
-    i1 = i0 + div.(bsz, 2)
+    i1 = i0 + div.(bsz, Tn2(2))
     i2 = i0 + bsz
-    j1 = j0 + div.(bsz, 2)
+    j1 = j0 + div.(bsz, Tn2(2))
     j2 = j0 + bsz
-    k1 = k0 + div.(bsz, 2)
+    k1 = k0 + div.(bsz, Tn2(2))
     k2 = k0 + bsz
 
     upper,lower,left,right,front,back = getNumberOfNeighbors(S);

--- a/src/getFaceConstraints.jl
+++ b/src/getFaceConstraints.jl
@@ -2,226 +2,229 @@ export getFaceConstraints
 
 function getFaceConstraints(M::OcTreeMesh)
 	if isempty(M.Nf)
-
+        T = eltype(M.h)
 		if all(M.S.SV.nzval.==M.S.SV.nzval[1]) # uniform mesh
-			M.Nf = speye(sum(M.nf))
-			M.Qf = speye(sum(M.nf))
-			M.activeFaces = [1:sum(M.nf);]
+			N    = typeof(M.nc)
+			M.Nf = speye(T,N,sum(M.nf))
+			M.Qf = speye(T,N,sum(M.nf))
+			M.activeFaces = collect(N,1:sum(M.nf))
 		else
-			M.Nf,M.Qf,Cf,M.activeFaces = getFaceConstraints(M.S)
+			M.Nf,M.Qf,Cf,M.activeFaces = getFaceConstraints(T,M.S)
 		end
 	end
 	return M.Nf,M.Qf,M.activeFaces
 end
 
-function getFaceConstraints(S::SparseArray3D)
-  #Eliminate hanging faces
-  #   C ... constraint matrix
-  #   N ... null space matrix (interpolation: coarse to fine)
-  #   Q ... projection matrix (restriction: fine to coarse)
-  #                     which satisfy Q * N = I
-  #                     (note that Q ~= N')
-  #   p ............... lookup table for new face enumeration:
-  #                     new face number = p(old face number)
-  #                     (returns zero for deleted faces)
-  i0,j0,k0,bsz = find3(S);
+function getFaceConstraints(::Type{Tf},S::SparseArray3D) where Tf
+    #Eliminate hanging faces
+    #   C ... constraint matrix
+    #   N ... null space matrix (interpolation: coarse to fine)
+    #   Q ... projection matrix (restriction: fine to coarse)
+    #                     which satisfy Q * N = I
+    #                     (note that Q ~= N')
+    #   p ............... lookup table for new face enumeration:
+    #                     new face number = p(old face number)
+    #                     (returns zero for deleted faces)
+    i0,j0,k0,bsz = find3(S);
 
-  i1 = i0 + div.(bsz, 2)
-  i2 = i0 + bsz
-  j1 = j0 + div.(bsz, 2)
-  j2 = j0 + bsz
-  k1 = k0 + div.(bsz, 2)
-  k2 = k0 + bsz
+    i1 = i0 + div.(bsz, 2)
+    i2 = i0 + bsz
+    j1 = j0 + div.(bsz, 2)
+    j2 = j0 + bsz
+    k1 = k0 + div.(bsz, 2)
+    k2 = k0 + bsz
 
-  upper,lower,left,right,front,back = getNumberOfNeighbors(S);
-  nn = [upper; lower; left; right; front; back];
-  if ~all( (nn .== 0) .| (nn .== 1) .| (nn .== 4) )
+    upper,lower,left,right,front,back = getNumberOfNeighbors(S);
+    nn = [upper; lower; left; right; front; back];
+    if ~all( (nn .== 0) .| (nn .== 1) .| (nn .== 4) )
     error("Implemented only for regularized OcTree meshes")
-  end
+    end
 
-  FNX,FNY,FNZ = getFaceNumbering(S);
+    FNX,FNY,FNZ = getFaceNumbering(S);
 
-  fx1 = Int64[]; fx2 = Int64[]; fx3 = Int64[]; fx4 = Int64[];
-  fy1 = Int64[]; fy2 = Int64[]; fy3 = Int64[]; fy4 = Int64[];
-  fz1 = Int64[]; fz2 = Int64[]; fz3 = Int64[]; fz4 = Int64[];
+	Tn  = eltype(FNX.SV.nzval)
+    fx1 = Tn[]; fx2 = Tn[]; fx3 = Tn[]; fx4 = Tn[];
+    fy1 = Tn[]; fy2 = Tn[]; fy3 = Tn[]; fy4 = Tn[];
+    fz1 = Tn[]; fz2 = Tn[]; fz3 = Tn[]; fz4 = Tn[];
 
 
-  #    ^ k z
-  #   /
-  #  /
-  # +-------> j y
-  # |
-  # |
-  # v x
-  #
-  #
-  # x-faces
-  #         +---------+---------+
-  #        /         /         /
-  #       /   fx3   /   fx4   /
-  #      /         /         /
-  #     +---------+---------+
-  #    /         /         /
-  #   /   fx1   /   fx2   /
-  #  /         /         /
-  # +---------+---------+
+    #    ^ k z
+    #   /
+    #  /
+    # +-------> j y
+    # |
+    # |
+    # v x
+    #
+    #
+    # x-faces
+    #         +---------+---------+
+    #        /         /         /
+    #       /   fx3   /   fx4   /
+    #      /         /         /
+    #     +---------+---------+
+    #    /         /         /
+    #   /   fx1   /   fx2   /
+    #  /         /         /
+    # +---------+---------+
 
-  I = (upper .== 4) # find  "bigger" cells
+    I = (upper .== 4) # find  "bigger" cells
 
-  if any(I)
+    if any(I)
     append!(fx1, FNX.SV[sub2ind(size(FNX), i0[I], j0[I], k0[I])])
     append!(fx2, FNX.SV[sub2ind(size(FNX), i0[I], j1[I], k0[I])])
     append!(fx3, FNX.SV[sub2ind(size(FNX), i0[I], j0[I], k1[I])])
     append!(fx4, FNX.SV[sub2ind(size(FNX), i0[I], j1[I], k1[I])])
-  end
+    end
 
-  I = (lower .== 4) # find  "bigger" cells
+    I = (lower .== 4) # find  "bigger" cells
 
-  if any(I)
+    if any(I)
     append!(fx1, FNX.SV[sub2ind(size(FNX), i2[I], j0[I], k0[I])])
     append!(fx2, FNX.SV[sub2ind(size(FNX), i2[I], j1[I], k0[I])])
     append!(fx3, FNX.SV[sub2ind(size(FNX), i2[I], j0[I], k1[I])])
     append!(fx4, FNX.SV[sub2ind(size(FNX), i2[I], j1[I], k1[I])])
-  end
+    end
 
 
-  ################################
+    ################################
 
-  I = (left .== 4) # find  "bigger" cells
+    I = (left .== 4) # find  "bigger" cells
 
-  if any(I)
+    if any(I)
     append!(fy1, FNY.SV[sub2ind(size(FNY), i0[I], j0[I], k0[I])])
     append!(fy2, FNY.SV[sub2ind(size(FNY), i1[I], j0[I], k0[I])])
     append!(fy3, FNY.SV[sub2ind(size(FNY), i0[I], j0[I], k1[I])])
     append!(fy4, FNY.SV[sub2ind(size(FNY), i1[I], j0[I], k1[I])])
-  end
+    end
 
-  I = (right .== 4) # find  "bigger" cells
+    I = (right .== 4) # find  "bigger" cells
 
-  if any(I)
+    if any(I)
     append!(fy1, FNY.SV[sub2ind(size(FNY), i0[I], j2[I], k0[I])])
     append!(fy2, FNY.SV[sub2ind(size(FNY), i1[I], j2[I], k0[I])])
     append!(fy3, FNY.SV[sub2ind(size(FNY), i0[I], j2[I], k1[I])])
     append!(fy4, FNY.SV[sub2ind(size(FNY), i1[I], j2[I], k1[I])])
-  end
+    end
 
-  ################################
+    ################################
 
-  I = (front .== 4) # find  "bigger" cells
+    I = (front .== 4) # find  "bigger" cells
 
-  if any(I)
+    if any(I)
     append!(fz1, FNZ.SV[sub2ind(size(FNZ), i0[I], j0[I], k0[I])])
     append!(fz2, FNZ.SV[sub2ind(size(FNZ), i1[I], j0[I], k0[I])])
     append!(fz3, FNZ.SV[sub2ind(size(FNZ), i0[I], j1[I], k0[I])])
     append!(fz4, FNZ.SV[sub2ind(size(FNZ), i1[I], j1[I], k0[I])])
-  end
+    end
 
-  I = (back .== 4) # find  "bigger" cells
+    I = (back .== 4) # find  "bigger" cells
 
-  if any(I)
+    if any(I)
     append!(fz1, FNZ.SV[sub2ind(size(FNZ), i0[I], j0[I], k2[I])])
     append!(fz2, FNZ.SV[sub2ind(size(FNZ), i1[I], j0[I], k2[I])])
     append!(fz3, FNZ.SV[sub2ind(size(FNZ), i0[I], j1[I], k2[I])])
     append!(fz4, FNZ.SV[sub2ind(size(FNZ), i1[I], j1[I], k2[I])])
-  end
+    end
 
-  #Convert from n x 1 arrays to vectors
-  fx1 = vec(fx1); fx2 = vec(fx2); fx3 = vec(fx3); fx4 = vec(fx4)
-  fy1 = vec(fy1); fy2 = vec(fy2); fy3 = vec(fy3); fy4 = vec(fy4)
-  fz1 = vec(fz1); fz2 = vec(fz2); fz3 = vec(fz3); fz4 = vec(fz4)
+    #Convert from n x 1 arrays to vectors
+    fx1 = vec(fx1); fx2 = vec(fx2); fx3 = vec(fx3); fx4 = vec(fx4)
+    fy1 = vec(fy1); fy2 = vec(fy2); fy3 = vec(fy3); fy4 = vec(fy4)
+    fz1 = vec(fz1); fz2 = vec(fz2); fz3 = vec(fz3); fz4 = vec(fz4)
 
 
-  ###################################################################
-  ##
-  ## Build interpolation matrix
-  ##
-  ###################################################################
-  #
-  # Constraint matrix
-  #
-  #    f1   f2   f3   f4
-  #     I   -I
-  #     I        -I
-  #     I             -I
-  #
-  # Null space matrix
-  #
-  #    f1 I
-  #    f2 I
-  #    f3 I
-  #    f4 I
+    ###################################################################
+    ##
+    ## Build interpolation matrix
+    ##
+    ###################################################################
+    #
+    # Constraint matrix
+    #
+    #    f1   f2   f3   f4
+    #     I   -I
+    #     I        -I
+    #     I             -I
+    #
+    # Null space matrix
+    #
+    #    f1 I
+    #    f2 I
+    #    f3 I
+    #    f4 I
 
-  nx = nnz(FNX); ny = nnz(FNY);  nz = nnz(FNZ);
+    nx  = Tn(nnz(FNX)); ny = Tn(nnz(FNY));  nz = Tn(nnz(FNZ));
+    Tn1 = one(Tn)
+    ## X faces
 
-  ## X faces
-  n  = length(fx1)*3
-  i  = vec(repmat([1:n;], 2, 1))
-  j  = [vec(repmat(fx1,3,1)); fx2; fx3; fx4]
-  v  = [ones(n); -ones(n)]
-  Cx = sparse(i,j,v,n,nx)
+    n  = Tn(length(fx1)*3)
+    i  = vec(repmat([Tn1:n;], 2, 1))
+    j  = [vec(repmat(fx1,3,1)); fx2; fx3; fx4]
+    v  = [ones(Tf,n); -ones(Tf,n)]
+    Cx = sparse(i,j,v,n,nx)
 
-  i = setdiff([1:nx;], [fx2; fx3; fx4])
-  n = length(i)
-  j = [1:n;]
-  px = zeros(Int64,nx)
-  px[i] = j
+    i  = setdiff([Tn1:nx;], [fx2; fx3; fx4])
+    n  = Tn(length(i))
+    j  = [Tn1:n;]
+    px = zeros(Tn,nx)
+    px[i] = j
 
-  tmp = intersect(fx1,i)
-  k   = indexin(tmp,i)
-  j   = [j; vec(repmat(j[k], 3, 1))]
-  i   = [i; fx2; fx3; fx4];
-  v   = ones(length(i))
-  Nx  = sparse(i,j,v,nx,n)
-  Qx  = spdiagm(vec(1./sum(Nx,1))) * Nx'
+    tmp = intersect(fx1,i)
+    k   = indexin(tmp,i)
+    j   = [j; vec(repmat(j[k], 3, 1))]
+    i   = [i; fx2; fx3; fx4];
+    v   = ones(Tf,length(i))
+    Nx  = sparse(i,j,v,nx,n)
+    Qx  = spdiagm(vec(one(Tf)./sum(Nx,1))) * Nx'
 
-  ## Y faces
-  n  = length(fy1)*3;
-  i  = vec(repmat([1:n;], 2, 1))
-  j  = [vec(repmat(fy1,3,1)); fy2; fy3; fy4];
-  v  = [ones(n); -ones(n)];
-  Cy = sparse(i,j,v,n,ny)
+    ## Y faces
+    n  = Tn(length(fy1)*3)
+    i  = vec(repmat([Tn1:n;], 2, 1))
+    j  = [vec(repmat(fy1,3,1)); fy2; fy3; fy4];
+    v  = [ones(Tf,n); -ones(Tf,n)];
+    Cy = sparse(i,j,v,n,ny)
 
-  i     = setdiff([1:ny;], [fy2; fy3; fy4]);
-  n     = length(i);
-  j     = [1:n;];
-  py    = zeros(Int64,ny)
-  py[i] = j + maximum(px);
+    i     = setdiff([Tn1:ny;], [fy2; fy3; fy4]);
+    n     = Tn(length(i))
+    j     = [Tn1:n;]
+    py    = zeros(Tn,ny)
+    py[i] = j + maximum(px);
 
-  tmp = intersect(fy1, i)
-  k   = indexin(tmp,i)
-  j   = [j; vec(repmat(j[k], 3, 1))]
-  i   = [i; fy2; fy3; fy4]
-  v   = ones(length(i))
-  Ny  = sparse(i,j,v,ny,n)
-  Qy  = spdiagm(vec(1./sum(Ny,1))) * Ny'
+    tmp = intersect(fy1, i)
+    k   = indexin(tmp,i)
+    j   = [j; vec(repmat(j[k], 3, 1))]
+    i   = [i; fy2; fy3; fy4]
+    v   = ones(Tf,length(i))
+    Ny  = sparse(i,j,v,ny,n)
+    Qy  = spdiagm(vec(1./sum(Ny,1))) * Ny'
 
-  ## Z faces
-  n  = length(fz1)*3
-  i  = vec(repmat([1:n;], 2, 1))
-  j  = [vec(repmat(fz1,3,1)); fz2; fz3; fz4]
-  v  = [ones(n); -ones(n)]
-  Cz = sparse(i,j,v,n,nz)
+    ## Z faces
+    n  = Tn(length(fz1)*3)
+    i  = vec(repmat([Tn1:n;], 2, 1))
+    j  = [vec(repmat(fz1,3,1)); fz2; fz3; fz4]
+    v  = [ones(Tf,n); -ones(Tf,n)]
+    Cz = sparse(i,j,v,n,nz)
 
-  i     = setdiff([1:nz;], [fz2; fz3; fz4])
-  n     = length(i)
-  j     = [1:n;]
-  pz    = zeros(Int64,nz)
-  pz[i] = j + maximum(py)
+    i     = setdiff([Tn1:nz;], [fz2; fz3; fz4])
+    n     = Tn(length(i))
+    j     = [Tn1:n;]
+    pz    = zeros(Tn,nz)
+    pz[i] = j + maximum(py)
 
-  tmp = intersect(fz1, i)
-  k   = indexin(tmp,i)
-  j   = [j; vec(repmat(j[k], 3, 1))]
-  i   = [i; fz2; fz3; fz4]
-  v   = ones(length(i))
-  Nz  = sparse(i,j,v,nz,n)
-  Qz  = spdiagm(vec(1./sum(Nz,1))) * Nz'
+    tmp = intersect(fz1, i)
+    k   = indexin(tmp,i)
+    j   = [j; vec(repmat(j[k], 3, 1))]
+    i   = [i; fz2; fz3; fz4]
+    v   = ones(Tf,length(i))
+    Nz  = sparse(i,j,v,nz,n)
+    Qz  = spdiagm(vec(one(Tf)./sum(Nz,1))) * Nz'
 
-  ## Put it all together
+    ## Put it all together
 
-  C  = blkdiag(Cx,Cy,Cz);
-  N  = blkdiag(Nx,Ny,Nz);
-  Q  = blkdiag(Qx,Qy,Qz);
-  p  = [px; py; pz];
+    C  = blkdiag(Cx,Cy,Cz);
+    N  = blkdiag(Nx,Ny,Nz);
+    Q  = blkdiag(Qx,Qy,Qz);
+    p  = [px; py; pz];
 
-  return N,Q,C,p
+    return N,Q,C,p
 end

--- a/src/getFaceInterpolationMatrix.jl
+++ b/src/getFaceInterpolationMatrix.jl
@@ -1,43 +1,44 @@
 export getFaceInterpolationMatrix
 
-function getFaceInterpolationMatrix(mesh::OcTreeMesh, x::Array{Float64,1}, y::Array{Float64,1}, z::Array{Float64,1})
-	
+function getFaceInterpolationMatrix(mesh::OcTreeMesh, x::Array{Tf,1}, y::Array{Tf,1}, z::Array{Tf,1}) where Tf <: Real
+
 	# map interpolation points to OcTree integer space
 	x = (x - mesh.x0[1]) / mesh.h[1] + 1.0
 	y = (y - mesh.x0[2]) / mesh.h[2] + 1.0
 	z = (z - mesh.x0[3]) / mesh.h[3] + 1.0
-	
+
 	# interpolation point numbers
-	n = length(x)
-	P = repmat([1:n;],2)
-	
+	Tn = typeof(mesh.nc)
+	n = Tn(length(x))
+	P = repmat([one(Tn):n;],2)
+
 	# get face enumeration
 	Fx,Fy,Fz = getFaceNumbering(mesh.S)
 	nx = nnz(Fx)
 	ny = nnz(Fy)
 	nz = nnz(Fz)
-	
+
 	# locate points within cells
 	i,j,k,bsz = findBlocks(mesh.S, floor(Integer,x), floor(Integer,y), floor(Integer,z))
-	
-	# x-face numbers 
+
+	# x-face numbers
 	I  = [i, i+bsz;]
 	J  = [j, j;]
 	K  = [k, k;]
 	Fx = vec(full(Fx.SV[sub2ind(size(Fx), I, J, K)]))
-	
-	# y-face numbers 
+
+	# y-face numbers
 	I  = [i, i;]
 	J  = [j, j+bsz;]
 	K  = [k, k;]
 	Fy = vec(full(Fy.SV[sub2ind(size(Fy), I, J, K)]))
-	
-	# z-face numbers 
+
+	# z-face numbers
 	I  = [i, i;]
 	J  = [j, j;]
 	K  = [k, k+bsz;]
 	Fz = vec(full(Fz.SV[sub2ind(size(Fz), I, J, K)]))
-	
+
 	# linear  basis
 	u2 = (x - i) ./ bsz
 	u1 = 1.0 - u2
@@ -45,17 +46,17 @@ function getFaceInterpolationMatrix(mesh::OcTreeMesh, x::Array{Float64,1}, y::Ar
 	v1 = 1.0 - v2
 	w2 = (z - k) ./ bsz
 	w1 = 1.0 - w2
-	
+
 	# linear interpolation
 	Qx = [u1, u2;] # constant along y and z
 	Qy = [v1, v2;] # constant along x and z
 	Qz = [w1, w2;] # constant along x and y
-	
+
 	# assemble sparse interpolation matrices
 	Qx = sparse(P, Fx, Qx, n, nx)
 	Qy = sparse(P, Fy, Qy, n, ny)
 	Qz = sparse(P, Fz, Qz, n, nz)
 
 	return Qx,Qy,Qz
-	
+
 end

--- a/src/getFaceMassMatrix.jl
+++ b/src/getFaceMassMatrix.jl
@@ -145,8 +145,8 @@ for isotropic, diagonally anisotropic or generally anisotropic coefficient.
 function setupFaceMassMatrix(mesh, sigma)
 
     na = length(sigma)
-    N = eltype(nc)
-    nc = mesh.nc
+    N = eltype(mesh.nc)
+    nc = N(mesh.nc)
 
     @assert in(na, [nc, 3*nc, 6*nc]) "Invalid size of sigma"
 

--- a/src/getFaceMassMatrix.jl
+++ b/src/getFaceMassMatrix.jl
@@ -54,7 +54,8 @@ function getdFaceMassMatrix{T<:Number}(mesh::OcTreeMeshFV, sigma::Vector, v::Vec
         dM = SparseMatrixCSC(P.A.m, P.A.n, copy(P.A.colptr), copy(P.A.rowval), T.(P.A.nzval))
         DiagTimesM(v, dM)
     else # generally anisotropic
-        V = SparseMatrixCSC(P.n, nz, collect(1:nz+1), P.rowval, v[P.colval])
+        N = eltype(P.A.colptr)
+        V = SparseMatrixCSC(P.n, nz, collect(N,1:nz+1), P.rowval, v[P.colval])
         dM = V * P.A
     end
     return dM
@@ -90,7 +91,8 @@ function dFaceMassMatrixTimesVector{T<:Number}(mesh::OcTreeMeshFV, sigma::Vector
         dMx = T.(P.A * x)
         dMx .*= v
     else # generally anisotropic
-        V = SparseMatrixCSC(P.n, nz, collect(1:nz+1), P.rowval, v[P.colval])
+        N = eltype(P.rowval)
+        V = SparseMatrixCSC(P.n, nz, collect(N,1:nz+1), P.rowval, v[P.colval])
         dMx = V * (P.A * x)
     end
     return dMx
@@ -124,7 +126,8 @@ function dFaceMassMatrixTrTimesVector{T<:Number}(mesh::OcTreeMeshFV, sigma::Vect
         u = conj.(v) .* x
         dMTx = P.A' * u
     else # generally anisotropic
-        V = SparseMatrixCSC(P.n, nz, collect(1:nz+1), P.rowval, v[P.colval])
+        N = eltype(P.rowval)
+        V = SparseMatrixCSC(P.n, nz, collect(N,1:nz+1), P.rowval, v[P.colval])
         u = V' * x
         dMTx = P.A' * u
     end
@@ -142,6 +145,7 @@ for isotropic, diagonally anisotropic or generally anisotropic coefficient.
 function setupFaceMassMatrix(mesh, sigma)
 
     na = length(sigma)
+    N = eltype(nc)
     nc = mesh.nc
 
     @assert in(na, [nc, 3*nc, 6*nc]) "Invalid size of sigma"
@@ -154,24 +158,24 @@ function setupFaceMassMatrix(mesh, sigma)
         if na == nc
 
             i = vcat(fx, fy, fz)
-            j = repmat(1:nc, 24)
+            j = repmat(one(N):nc, 24)
             a = repmat(w, 24)
             A = sparse(i, j, a, n, na)
-            colptr = collect(1:n+1)
-            rowval = collect(1:n)
-            colval = Array{Int64}(0) # unused
+            colptr = collect(N,1:n+1)
+            rowval = collect(N,1:n)
+            colval = Array{N}(0) # unused
 
         elseif na == 3 * nc
 
             i = vcat(fx, fy, fz)
-            j = vcat(repmat(     1:  nc, 8),
-                     repmat(  nc+1:2*nc, 8),
-                     repmat(2*nc+1:3*nc, 8))
+            j = vcat(repmat(UnitRange{N}(     1:  nc), 8),
+                     repmat(UnitRange{N}(  nc+1:2*nc), 8),
+                     repmat(UnitRange{N}(2*nc+1:3*nc), 8))
             a = repmat(w, 24)
             A = sparse(i, j, a, n, na)
-            colptr = collect(1:n+1)
-            rowval = collect(1:n)
-            colval = Array{Int64}(0) # unused
+            colptr = collect(N,1:n+1)
+            rowval = collect(N,1:n)
+            colval = Array{N}(0) # unused
 
         elseif na == 6 * nc
 
@@ -193,15 +197,15 @@ function setupFaceMassMatrix(mesh, sigma)
 
             # construct mapping of anisotropic cell property to
             # nonzero entries in mass matrix
-            j = vcat(repmat(     1:  nc, 8),
-                     repmat(  nc+1:2*nc, 8),
-                     repmat(2*nc+1:3*nc, 8),
-                     repmat(3*nc+1:4*nc, 8),
-                     repmat(4*nc+1:5*nc, 8),
-                     repmat(5*nc+1:6*nc, 8),
-                     repmat(3*nc+1:4*nc, 8),
-                     repmat(4*nc+1:5*nc, 8),
-                     repmat(5*nc+1:6*nc, 8))
+            j = vcat(repmat(UnitRange{N}(     1:  nc), 8),
+                     repmat(UnitRange{N}(  nc+1:2*nc), 8),
+                     repmat(UnitRange{N}(2*nc+1:3*nc), 8),
+                     repmat(UnitRange{N}(3*nc+1:4*nc), 8),
+                     repmat(UnitRange{N}(4*nc+1:5*nc), 8),
+                     repmat(UnitRange{N}(5*nc+1:6*nc), 8),
+                     repmat(UnitRange{N}(3*nc+1:4*nc), 8),
+                     repmat(UnitRange{N}(4*nc+1:5*nc), 8),
+                     repmat(UnitRange{N}(5*nc+1:6*nc), 8))
             a = repmat(w, 72)
             A = sparse(i, j, a, nz, na)
 

--- a/src/getFaceToCellCenteredMatrix.jl
+++ b/src/getFaceToCellCenteredMatrix.jl
@@ -13,9 +13,9 @@ function getFaceToCellCenteredMatrixAnisotropic(S::SparseArray3D)
 #
 
 n = S.sz;
-nex = n + [1, 0, 0]
-ney = n + [0, 1, 0]
-nez = n + [0, 0, 1]
+nex = (n[1]+1,n[2],n[3])
+ney = (n[1],n[2]+1,n[3])
+nez = (n[1],n[2],n[3]+1)
 
 i,j,k,bsz = find3(S)
 ex,ey,ez = getFaceNumbering(S)

--- a/src/getFaceToCellCenteredMatrix.jl
+++ b/src/getFaceToCellCenteredMatrix.jl
@@ -2,7 +2,8 @@ export getFaceToCellCenteredMatrix, getFaceAverageMatrix
 
 function getFaceAverageMatrix(M::OcTreeMesh)
 	if isempty(M.Af)
-		M.Af, = getFaceToCellCenteredMatrix(M.S)
+		Tf = eltype(M.h)
+		M.Af, = getFaceToCellCenteredMatrix(Tf,M.S)
 	end
 	return M.Af
 end
@@ -33,14 +34,15 @@ Py2 = ey.SV[sub2ind(ney,i,j+bsz,k),1]
 Pz1 = ez.SV[sub2ind(nez,i,j,k),1]
 Pz2 = ez.SV[sub2ind(nez,i,j,k+bsz),1]
 
+Tn = eltype(S.SV.nzval)
+Tn1 = one(Tn)
+sp1(Q) = sparse(Tn1:Tn(Base.nnz(Q)),Tn(Base.nonzeros(Q)),ones(Base.nnz(Q)),nc,nx)
+sp2(Q) = sparse(Tn1:Tn(Base.nnz(Q)),Tn(Base.nonzeros(Q)),ones(Base.nnz(Q)),nc,ny)
+sp3(Q) = sparse(Tn1:Tn(Base.nnz(Q)),Tn(Base.nonzeros(Q)),ones(Base.nnz(Q)),nc,nz)
 
-sp1(Q) = sparse(1:Base.nnz(Q),Base.nonzeros(Q),ones(Base.nnz(Q)),nc,nx)
-sp2(Q) = sparse(1:Base.nnz(Q),Base.nonzeros(Q),ones(Base.nnz(Q)),nc,ny)
-sp3(Q) = sparse(1:Base.nnz(Q),Base.nonzeros(Q),ones(Base.nnz(Q)),nc,nz)
-
-Ax = 0.5*(sp1(Px1) + sp1(Px2));
-Ay = 0.5*(sp2(Py1) + sp2(Py2));
-Az = 0.5*(sp3(Pz1) + sp3(Pz2));
+Ax = 0.5*(sp1(Px1) + sp1(Px2))
+Ay = 0.5*(sp2(Py1) + sp2(Py2))
+Az = 0.5*(sp3(Pz1) + sp3(Pz2))
 
 Af = [Ax Ay Az]
 
@@ -48,26 +50,26 @@ return Af, Ax, Ay, Az
 
 end
 
-function getFaceToCellCenteredMatrix(S)
+function getFaceToCellCenteredMatrix(::Type{Tf},S) where Tf <: Number
 # [A, A1, A2, A3] = getFaceToCellCenteredMatrix(S)
 
-A      = getDivergenceMatrixRec(S,[1,1,1])
+A      = getDivergenceMatrixRec(S,ones(Tf,3))
 FX,FY,FZ = getFaceSize(S)
 
 HF = vcat(nonzeros(FX), nonzeros(FY), nonzeros(FZ))
 
-fill!(A.nzval, 1.0)
+fill!(A.nzval, one(Tf))
 
 HF = HF.^2
 A = MTimesDiag(A, HF)
 
 NF1 = nnz(FX); NF2 = nnz(FY); NF3 = nnz(FZ);
-A1 = A[:,1:NF1]; A2 = A[:,(1+NF1):(NF1+NF2)];  A3 = A[:,(1+NF1+NF2):end]; 
+A1 = A[:,1:NF1]; A2 = A[:,(1+NF1):(NF1+NF2)];  A3 = A[:,(1+NF1+NF2):end];
 
 # make sure it sums to 1.
-W1 = 1. ./ vec(sum(A1,2))
-W2 = 1. ./ vec(sum(A2,2))
-W3 = 1. ./ vec(sum(A3,2))
+W1 = one(Tf) ./ vec(sum(A1,2))
+W2 = one(Tf) ./ vec(sum(A2,2))
+W3 = one(Tf) ./ vec(sum(A3,2))
 
 #A1 = W1*A1; A2 = W2*A2; A3 = W3*A3;
 A1 = DiagTimesM(W1, A1)

--- a/src/getNodalConstraints.jl
+++ b/src/getNodalConstraints.jl
@@ -18,13 +18,16 @@ end
 function getNodalConstraints(::Type{Tf},S::SparseArray3D) where Tf
     i,j,k,bsz = find3(S)
 
+
     upper,lower,left,right,front,back = getNumberOfNeighbors(S)
     nn = [upper; lower; left; right; front; back]
     if ~all( (nn .== 0) .| (nn .== 1) .| (nn .== 4) )
     error("Implemented only for regularized OcTree meshes")
     end
     NN = getNodalNumbering(S)
-    Tn = eltype(NN.SV.nzval)
+    Tn  = eltype(NN.SV.nzval)
+    Tn2 = eltype(NN.SV.nzind)
+    bsz = convert(Vector{Tn2},bsz)
     n1 = Tn[]; n2 = Tn[]; n3 = Tn[];
     n4 = Tn[]; n5 = Tn[]; n6 = Tn[];
     n7 = Tn[]; n8 = Tn[]; n9 = Tn[];
@@ -49,7 +52,7 @@ function getNodalConstraints(::Type{Tf},S::SparseArray3D) where Tf
     # n1--------n2--------n3
 
     I = find(upper.==4) #find "bigger" cells
-    bsz2 = div.(bsz[I],2)
+    bsz2 = div.(bsz[I],Tn2(2))
 
     if !isempty(I)
     append!(n1, NN.SV[sub2ind(size(NN), i[I], j[I]        , k[I]        )])
@@ -64,7 +67,7 @@ function getNodalConstraints(::Type{Tf},S::SparseArray3D) where Tf
     end
 
     I = find(lower.==4) # find  "bigger" cells
-    bsz2 = div.(bsz[I],2)
+    bsz2 = div.(bsz[I],Tn2(2))
 
     if !isempty(I)
     append!(n1, NN.SV[sub2ind(size(NN), i[I]+bsz[I], j[I]        , k[I]       )])
@@ -81,7 +84,7 @@ function getNodalConstraints(::Type{Tf},S::SparseArray3D) where Tf
     ##################################
 
     I = find(left .== 4) # find  "bigger" cells
-    bsz2 = div.(bsz[I],2)
+    bsz2 = div.(bsz[I],Tn2(2))
 
     if !isempty(I)
     append!(n1, NN.SV[sub2ind(size(NN), i[I]        , j[I], k[I]        )])
@@ -96,7 +99,7 @@ function getNodalConstraints(::Type{Tf},S::SparseArray3D) where Tf
     end
 
     I = find(right .== 4) # find  "bigger" cells
-    bsz2 = div.(bsz[I],2)
+    bsz2 = div.(bsz[I],Tn2(2))
 
     if !isempty(I)
     append!(n1, NN.SV[sub2ind(size(NN), i[I]         , j[I]+bsz[I], k[I]        )])
@@ -113,7 +116,7 @@ function getNodalConstraints(::Type{Tf},S::SparseArray3D) where Tf
     ##################################
 
     I = find(front .== 4) # find  "bigger" cells
-    bsz2 = div.(bsz[I],2)
+    bsz2 = div.(bsz[I],Tn2(2))
 
     if !isempty(I)
     append!(n1, NN.SV[sub2ind(size(NN), i[I]         , j[I]        , k[I] )])
@@ -128,7 +131,7 @@ function getNodalConstraints(::Type{Tf},S::SparseArray3D) where Tf
     end
 
     I = find(back .== 4) # find  "bigger" cells
-    bsz2 = div.(bsz[I],2)
+    bsz2 = div.(bsz[I],Tn2(2))
 
     if !isempty(I)
     append!(n1, NN.SV[sub2ind(size(NN), i[I]        , j[I]        , k[I]+bsz[I] )])

--- a/src/getNodalConstraints.jl
+++ b/src/getNodalConstraints.jl
@@ -1,54 +1,57 @@
 export getNodalConstraints
 
 function getNodalConstraints(M::OcTreeMesh)
-  if isempty(M.Nn)
-    if all(M.S.SV.nzval.==M.S.SV.nzval[1]) # uniform mesh
-      Nn = prod(M.n+1)
-      M.Nn = speye(Nn)
-      M.Qn = speye(Nn)
-    else
-      M.Nn,M.Qn,Cn,M.activeNodes = getNodalConstraints(M.S)
+    if isempty(M.Nn)
+        T = eltype(M.h)
+        if all(M.S.SV.nzval.==M.S.SV.nzval[1]) # uniform mesh
+            N = typeof(M.nc)
+            Nn = prod(M.n+1)
+            M.Nn = speye(Nn)
+            M.Qn = speye(Nn)
+        else
+            M.Nn,M.Qn,Cn,M.activeNodes = getNodalConstraints(T,M.S)
+        end
     end
-  end
-  return M.Nn,M.Qn,M.activeNodes
+    return M.Nn,M.Qn,M.activeNodes
 end
 
-function getNodalConstraints(S::SparseArray3D)
-  i,j,k,bsz = find3(S)
+function getNodalConstraints(::Type{Tf},S::SparseArray3D) where Tf
+    i,j,k,bsz = find3(S)
 
-  upper,lower,left,right,front,back = getNumberOfNeighbors(S)
-  nn = [upper; lower; left; right; front; back]
-  if ~all( (nn .== 0) .| (nn .== 1) .| (nn .== 4) )
+    upper,lower,left,right,front,back = getNumberOfNeighbors(S)
+    nn = [upper; lower; left; right; front; back]
+    if ~all( (nn .== 0) .| (nn .== 1) .| (nn .== 4) )
     error("Implemented only for regularized OcTree meshes")
-  end
-  NN = getNodalNumbering(S)
-  n1 = Int64[]; n2 = Int64[]; n3 = Int64[];
-  n4 = Int64[]; n5 = Int64[]; n6 = Int64[];
-  n7 = Int64[]; n8 = Int64[]; n9 = Int64[];
+    end
+    NN = getNodalNumbering(S)
+    Tn = eltype(NN.SV.nzval)
+    n1 = Tn[]; n2 = Tn[]; n3 = Tn[];
+    n4 = Tn[]; n5 = Tn[]; n6 = Tn[];
+    n7 = Tn[]; n8 = Tn[]; n9 = Tn[];
 
-  #    ^ k z
-  #   /
-  #  /
-  # +-------> j y
-  # |
-  # |
-  # v x
+    #    ^ k z
+    #   /
+    #  /
+    # +-------> j y
+    # |
+    # |
+    # v x
 
 
-  #         n7--------n8--------n9
-  #         /         /         /
-  #        /         /         /
-  #       /         /         /
-  #     n4--------n5--------n6
-  #     /         /         /
-  #    /         /         /
-  #   /         /         /
-  # n1--------n2--------n3
+    #         n7--------n8--------n9
+    #         /         /         /
+    #        /         /         /
+    #       /         /         /
+    #     n4--------n5--------n6
+    #     /         /         /
+    #    /         /         /
+    #   /         /         /
+    # n1--------n2--------n3
 
-  I = find(upper.==4) #find "bigger" cells
-  bsz2 = div.(bsz[I],2)
+    I = find(upper.==4) #find "bigger" cells
+    bsz2 = div.(bsz[I],2)
 
-  if !isempty(I)
+    if !isempty(I)
     append!(n1, NN.SV[sub2ind(size(NN), i[I], j[I]        , k[I]        )])
     append!(n2, NN.SV[sub2ind(size(NN), i[I], j[I]+bsz2   , k[I]        )])
     append!(n3, NN.SV[sub2ind(size(NN), i[I], j[I]+bsz[I] , k[I]        )])
@@ -58,12 +61,12 @@ function getNodalConstraints(S::SparseArray3D)
     append!(n7, NN.SV[sub2ind(size(NN), i[I], j[I]        , k[I]+bsz[I] )])
     append!(n8, NN.SV[sub2ind(size(NN), i[I], j[I]+bsz2   , k[I]+bsz[I] )])
     append!(n9, NN.SV[sub2ind(size(NN), i[I], j[I]+bsz[I] , k[I]+bsz[I] )])
-  end
+    end
 
-  I = find(lower.==4) # find  "bigger" cells
-  bsz2 = div.(bsz[I],2)
+    I = find(lower.==4) # find  "bigger" cells
+    bsz2 = div.(bsz[I],2)
 
-  if !isempty(I)
+    if !isempty(I)
     append!(n1, NN.SV[sub2ind(size(NN), i[I]+bsz[I], j[I]        , k[I]       )])
     append!(n2, NN.SV[sub2ind(size(NN), i[I]+bsz[I], j[I]+bsz2   , k[I]       )])
     append!(n3, NN.SV[sub2ind(size(NN), i[I]+bsz[I], j[I]+bsz[I] , k[I]       )])
@@ -73,14 +76,14 @@ function getNodalConstraints(S::SparseArray3D)
     append!(n7, NN.SV[sub2ind(size(NN), i[I]+bsz[I], j[I]        , k[I]+bsz[I])])
     append!(n8, NN.SV[sub2ind(size(NN), i[I]+bsz[I], j[I]+bsz2   , k[I]+bsz[I])])
     append!(n9, NN.SV[sub2ind(size(NN), i[I]+bsz[I], j[I]+bsz[I] , k[I]+bsz[I])])
-  end
+    end
 
-  ##################################
+    ##################################
 
-  I = find(left .== 4) # find  "bigger" cells
-  bsz2 = div.(bsz[I],2)
+    I = find(left .== 4) # find  "bigger" cells
+    bsz2 = div.(bsz[I],2)
 
-  if !isempty(I)
+    if !isempty(I)
     append!(n1, NN.SV[sub2ind(size(NN), i[I]        , j[I], k[I]        )])
     append!(n2, NN.SV[sub2ind(size(NN), i[I]+bsz2   , j[I], k[I]        )])
     append!(n3, NN.SV[sub2ind(size(NN), i[I]+bsz[I] , j[I], k[I]        )])
@@ -90,12 +93,12 @@ function getNodalConstraints(S::SparseArray3D)
     append!(n7, NN.SV[sub2ind(size(NN), i[I]        , j[I], k[I]+bsz[I] )])
     append!(n8, NN.SV[sub2ind(size(NN), i[I]+bsz2   , j[I], k[I]+bsz[I] )])
     append!(n9, NN.SV[sub2ind(size(NN), i[I]+bsz[I] , j[I], k[I]+bsz[I] )])
-  end
+    end
 
-  I = find(right .== 4) # find  "bigger" cells
-  bsz2 = div.(bsz[I],2)
+    I = find(right .== 4) # find  "bigger" cells
+    bsz2 = div.(bsz[I],2)
 
-  if !isempty(I)
+    if !isempty(I)
     append!(n1, NN.SV[sub2ind(size(NN), i[I]         , j[I]+bsz[I], k[I]        )])
     append!(n2, NN.SV[sub2ind(size(NN), i[I]+bsz2    , j[I]+bsz[I], k[I]        )])
     append!(n3, NN.SV[sub2ind(size(NN), i[I]+bsz[I]  , j[I]+bsz[I], k[I]        )])
@@ -105,14 +108,14 @@ function getNodalConstraints(S::SparseArray3D)
     append!(n7, NN.SV[sub2ind(size(NN), i[I]         , j[I]+bsz[I], k[I]+bsz[I] )])
     append!(n8, NN.SV[sub2ind(size(NN), i[I]+bsz2    , j[I]+bsz[I], k[I]+bsz[I] )])
     append!(n9, NN.SV[sub2ind(size(NN), i[I]+bsz[I]  , j[I]+bsz[I], k[I]+bsz[I] )])
-  end
+    end
 
-  ##################################
+    ##################################
 
-  I = find(front .== 4) # find  "bigger" cells
-  bsz2 = div.(bsz[I],2)
+    I = find(front .== 4) # find  "bigger" cells
+    bsz2 = div.(bsz[I],2)
 
-  if !isempty(I)
+    if !isempty(I)
     append!(n1, NN.SV[sub2ind(size(NN), i[I]         , j[I]        , k[I] )])
     append!(n2, NN.SV[sub2ind(size(NN), i[I]+bsz2    , j[I]        , k[I] )])
     append!(n3, NN.SV[sub2ind(size(NN), i[I]+bsz[I]  , j[I]        , k[I] )])
@@ -122,12 +125,12 @@ function getNodalConstraints(S::SparseArray3D)
     append!(n7, NN.SV[sub2ind(size(NN), i[I]         , j[I]+bsz[I] , k[I] )])
     append!(n8, NN.SV[sub2ind(size(NN), i[I]+bsz2    , j[I]+bsz[I] , k[I] )])
     append!(n9, NN.SV[sub2ind(size(NN), i[I]+bsz[I]  , j[I]+bsz[I] , k[I] )])
-  end
+    end
 
-  I = find(back .== 4) # find  "bigger" cells
-  bsz2 = div.(bsz[I],2)
+    I = find(back .== 4) # find  "bigger" cells
+    bsz2 = div.(bsz[I],2)
 
-  if !isempty(I)
+    if !isempty(I)
     append!(n1, NN.SV[sub2ind(size(NN), i[I]        , j[I]        , k[I]+bsz[I] )])
     append!(n2, NN.SV[sub2ind(size(NN), i[I]+bsz2   , j[I]        , k[I]+bsz[I] )])
     append!(n3, NN.SV[sub2ind(size(NN), i[I]+bsz[I] , j[I]        , k[I]+bsz[I] )])
@@ -137,88 +140,89 @@ function getNodalConstraints(S::SparseArray3D)
     append!(n7, NN.SV[sub2ind(size(NN), i[I]        , j[I]+bsz[I] , k[I]+bsz[I] )])
     append!(n8, NN.SV[sub2ind(size(NN), i[I]+bsz2   , j[I]+bsz[I] , k[I]+bsz[I] )])
     append!(n9, NN.SV[sub2ind(size(NN), i[I]+bsz[I] , j[I]+bsz[I] , k[I]+bsz[I] )])
-  end
+    end
 
-  ###################################################################
-  ##
-  ## Build interpolation matrix
-  ##
-  ###################################################################
-  # Constraint matrix
-  #
-  #   n1  n3  n7  n9  n2  n4  n6  n8  n5
-  #  I/2 I/2          -I
-  #  I/2     I/2          -I
-  #      I/2     I/2          -I
-  #          I/2 I/2              -I
-  #  I/4 I/4 I/4 I/4                  -I
-  #
-  # Null space matrix
-  #
-  #  n1 I
-  #  n3     I
-  #  n7         I
-  #  n9             I
-  #  n2 I/2 I/2
-  #  n4 I/2     I/2
-  #  n6     I/2     I/2
-  #  n8         I/2 I/2
-  #  n5 I/4 I/4 I/4 I/4
+    ###################################################################
+    ##
+    ## Build interpolation matrix
+    ##
+    ###################################################################
+    # Constraint matrix
+    #
+    #   n1  n3  n7  n9  n2  n4  n6  n8  n5
+    #  I/2 I/2          -I
+    #  I/2     I/2          -I
+    #      I/2     I/2          -I
+    #          I/2 I/2              -I
+    #  I/4 I/4 I/4 I/4                  -I
+    #
+    # Null space matrix
+    #
+    #  n1 I
+    #  n3     I
+    #  n7         I
+    #  n9             I
+    #  n2 I/2 I/2
+    #  n4 I/2     I/2
+    #  n6     I/2     I/2
+    #  n8         I/2 I/2
+    #  n5 I/4 I/4 I/4 I/4
 
-  n = nnz(NN)
-  I = speye(n)
+    n = Tn(nnz(NN))
+    I = speye(Tf,Tn,n)
 
-  # eliminate nodes at edge centers (n2,n4,n6,n8)
-  i1 = [n1;n1;n3;n7]
-  i2 = [n3;n7;n9;n9]
-  i3 = [n2;n4;n6;n8]
-  i3orig = copy(i3)
-  i3 = unique(i3)
-  i = indexin(i3,i3orig)
-  i3orig = 0.0
-  i1 = i1[i]
-  i2 = i2[i]
-  A1 = I[i1,:]/2 + I[i2,:]/2
-  B1 = I[i3,:]
+    # eliminate nodes at edge centers (n2,n4,n6,n8)
+    i1 = [n1;n1;n3;n7]
+    i2 = [n3;n7;n9;n9]
+    i3 = [n2;n4;n6;n8]
+    i3orig = copy(i3)
+    i3 = unique(i3)
+    i = indexin(i3,i3orig)
+    i3orig = 0.0
+    i1 = i1[i]
+    i2 = i2[i]
+    A1 = I[i1,:]/2 + I[i2,:]/2
+    B1 = I[i3,:]
 
-  # eliminate nodes at face centers (n5)
-  j  = sortperm(vec(n5))
-  j5 = n5[j]
-  j1 = n1[j]
-  j2 = n3[j]
-  j3 = n7[j]
-  j4 = n9[j]
-  A2 = I[j1,:]/4 + I[j2,:]/4 + I[j3,:]/4 + I[j4,:]/4;
-  B2 = I[j5,:]
+    # eliminate nodes at face centers (n5)
+    j  = sortperm(vec(n5))
+    j5 = n5[j]
+    j1 = n1[j]
+    j2 = n3[j]
+    j3 = n7[j]
+    j4 = n9[j]
+    A2 = I[j1,:]/4 + I[j2,:]/4 + I[j3,:]/4 + I[j4,:]/4;
+    B2 = I[j5,:]
 
-  A = [A1; A2]
-  B = [B1; B2]
+    A = [A1; A2]
+    B = [B1; B2]
 
-  # permute rows and columns for matrix splitting
-  k2 = sort([i3; j5])
-  p  = sortperm([i3; j5])
-  k1 = setdiff([1:n;], k2)
-  q  = [k1; k2]
-  A  = A[p,q]
-  B  = B[p,q]
-  m  = n - length(p);
+    # permute rows and columns for matrix splitting
+    Tn1 = one(Tn)
+    k2 = sort([i3; j5])
+    p  = sortperm([i3; j5])
+    k1 = setdiff([Tn1:n;], k2)
+    q  = [k1; k2]
+    A  = A[p,q]
+    B  = B[p,q]
+    m  = n - length(p);
 
-  C = A - B;
-  N = [
-  speye(m)
-  A[:,1:m]]
-  Q = [speye(m) spzeros(m,length(p))]
+    C = A - B;
+    N = [
+    speye(m)
+    A[:,1:m]]
+    Q = [speye(m) spzeros(m,length(p))]
 
-  # permute back
-  p = sortperm(q)
-  C = C[:,p]
-  N = N[p,:]
-  Q = Q[:,p]
+    # permute back
+    p = sortperm(q)
+    C = C[:,p]
+    N = N[p,:]
+    Q = Q[:,p]
 
-  # table lookup for new nodal numbering
-  p = zeros(Int64,n)
-  p[k1] = 1:length(k1)
-  
-  return N,Q,C,p
-  
+    # table lookup for new nodal numbering
+    p = zeros(Tn,n)
+    p[k1] = 1:length(k1)
+
+    return N,Q,C,p
+
 end

--- a/src/getNodalGradientRec.jl
+++ b/src/getNodalGradientRec.jl
@@ -16,6 +16,7 @@ function getNodalGradientRec(M)
 
 
 S = M.S; h = M.h
+T = typeof(h)
 N           = getNodalNumbering(M)
 EX,EY,EZ, ENX,ENY,ENZ = getEdgeSizeNumbering(M)
 
@@ -23,14 +24,14 @@ i,j,k,esz = find3(EX)  #; esz = round(Int64,esz)
 
 ii = [ nonzeros(ENX)              ; nonzeros(ENX)                     ]
 jj = [ N.SV[sub2ind(N.sz,i,j,k)]    ; N.SV[sub2ind(N.sz ,i+esz,j,k)] ]
-vv = [ -ones(length(i))             ; ones(length(i))                 ]
+vv = [ -ones(T,length(i))             ; ones(T,length(i))                 ]
 
 G1 = sparse(ii, jj, vv, nnz(EX), nnz(N))
 
 i,j,k,esz = find3(EY) #;  esz = round(Int64,esz)
 ii = [ nonzeros(ENY)              ; nonzeros(ENY)                      ]
 jj = [ N.SV[sub2ind(N.sz,i,j,k)]    ; N.SV[sub2ind(N.sz ,i,j+esz,k)] ]
-vv = [ -ones(length(i))             ; ones(length(i))                  ]
+vv = [ -ones(T,length(i))             ; ones(T,length(i))                  ]
 
 G2 = sparse(ii, jj, vv, nnz(EY), nnz(N))
 
@@ -38,13 +39,13 @@ G2 = sparse(ii, jj, vv, nnz(EY), nnz(N))
 i,j,k,esz = find3(EZ) #;  esz = round(Int64,esz)
 ii = [ nonzeros(ENZ)              ; nonzeros(ENZ)                     ]
 jj = [ N.SV[sub2ind(N.sz,i,j,k)]  ; N.SV[sub2ind(N.sz  ,i,j,k+esz)] ]
-vv = [ -ones(size(i))             ; ones(size(i))                     ]
+vv = [ -ones(T,size(i))             ; ones(T,size(i))                     ]
 
 G3 = sparse(ii, jj, vv, nnz(EZ), nnz(N));
 
 G = [G1 ; G2 ; G3];
 
-ESZi = 1. ./ vcat(nonzeros(EX)*h[1],
+ESZi = one(T) ./ vcat(nonzeros(EX)*h[1],
                   nonzeros(EY)*h[2],
                   nonzeros(EZ)*h[3] )
 

--- a/src/getNodalGradientRec.jl
+++ b/src/getNodalGradientRec.jl
@@ -16,7 +16,7 @@ function getNodalGradientRec(M)
 
 
 S = M.S; h = M.h
-T = typeof(h)
+T = eltype(h)
 N           = getNodalNumbering(M)
 EX,EY,EZ, ENX,ENY,ENZ = getEdgeSizeNumbering(M)
 

--- a/src/getNodalGradientRec.jl
+++ b/src/getNodalGradientRec.jl
@@ -16,21 +16,22 @@ function getNodalGradientRec(M)
 
 
 S = M.S; h = M.h
-T = eltype(h)
+T   = eltype(h)
+Tn2 = eltype(S.SV.nzind)
 N           = getNodalNumbering(M)
 EX,EY,EZ, ENX,ENY,ENZ = getEdgeSizeNumbering(M)
 
 i,j,k,esz = find3(EX)  #; esz = round(Int64,esz)
 
 ii = [ nonzeros(ENX)              ; nonzeros(ENX)                     ]
-jj = [ N.SV[sub2ind(N.sz,i,j,k)]    ; N.SV[sub2ind(N.sz ,i+esz,j,k)] ]
+jj = [ N.SV[sub2ind(N.sz,i,j,k)]    ; N.SV[sub2ind(N.sz ,convert(Vector{Tn2},i+esz),j,k)] ]
 vv = [ -ones(T,length(i))             ; ones(T,length(i))                 ]
 
 G1 = sparse(ii, jj, vv, nnz(EX), nnz(N))
 
 i,j,k,esz = find3(EY) #;  esz = round(Int64,esz)
 ii = [ nonzeros(ENY)              ; nonzeros(ENY)                      ]
-jj = [ N.SV[sub2ind(N.sz,i,j,k)]    ; N.SV[sub2ind(N.sz ,i,j+esz,k)] ]
+jj = [ N.SV[sub2ind(N.sz,i,j,k)]    ; N.SV[sub2ind(N.sz ,i,convert(Vector{Tn2},j+esz),k)] ]
 vv = [ -ones(T,length(i))             ; ones(T,length(i))                  ]
 
 G2 = sparse(ii, jj, vv, nnz(EY), nnz(N))
@@ -38,7 +39,7 @@ G2 = sparse(ii, jj, vv, nnz(EY), nnz(N))
 
 i,j,k,esz = find3(EZ) #;  esz = round(Int64,esz)
 ii = [ nonzeros(ENZ)              ; nonzeros(ENZ)                     ]
-jj = [ N.SV[sub2ind(N.sz,i,j,k)]  ; N.SV[sub2ind(N.sz  ,i,j,k+esz)] ]
+jj = [ N.SV[sub2ind(N.sz,i,j,k)]  ; N.SV[sub2ind(N.sz  ,i,j,convert(Vector{Tn2},k+esz))] ]
 vv = [ -ones(T,size(i))             ; ones(T,size(i))                     ]
 
 G3 = sparse(ii, jj, vv, nnz(EZ), nnz(N));

--- a/src/getNodalInterpolationMatrix.jl
+++ b/src/getNodalInterpolationMatrix.jl
@@ -1,29 +1,30 @@
 export getNodalInterpolationMatrix
 
-function getNodalInterpolationMatrix(mesh::OcTreeMesh, x::Array{Float64,1}, y::Array{Float64,1}, z::Array{Float64,1})
-	
+function getNodalInterpolationMatrix(mesh::OcTreeMesh, x::Array{Tf,1}, y::Array{Tf,1}, z::Array{Tf,1}) where Tf <: Real
+
 	# map interpolation points to OcTree integer space
 	x = (x - mesh.x0[1]) / mesh.h[1] + 1.0
 	y = (y - mesh.x0[2]) / mesh.h[2] + 1.0
 	z = (z - mesh.x0[3]) / mesh.h[3] + 1.0
-	
+
 	# interpolation point numbers
-	n = length(x)
-	P = repmat([1:n;],8)
-	
+	Tn = eltype(mesh.S.SV.nzval)
+	n  = Tn(length(x))
+	P  = repmat([one(Tn):n;],8)
+
 	# get nodal enumeration
 	N = getNodalNumbering(mesh)
 	nn = nnz(N)
-	
+
 	# locate points within cells
 	i,j,k,bsz = findBlocks(mesh.S, floor.(Integer,x), floor.(Integer,y), floor.(Integer,z))
-	
-	# node numbers 
+
+	# node numbers
 	I = [i, i+bsz, i, i+bsz, i, i+bsz, i, i+bsz;]
 	J = [j, j, j+bsz, j+bsz, j, j, j+bsz, j+bsz;]
 	K = [k, k, k, k, k+bsz, k+bsz, k+bsz, k+bsz;]
 	N = vec(full(N.SV[sub2ind(size(N), I,J,K)]));
-	
+
 	# trilinear interpolation
 	xd = (x-i)./bsz
 	yd = (y-j)./bsz
@@ -44,5 +45,5 @@ function getNodalInterpolationMatrix(mesh::OcTreeMesh, x::Array{Float64,1}, y::A
 	Q = sparse(P, N, Q, n, nn)
 
 	return Q
-	
+
 end

--- a/src/getNodalMassMatrix.jl
+++ b/src/getNodalMassMatrix.jl
@@ -136,7 +136,7 @@ function setupNodalMassMatrix(mesh, sigma)
         rowval = collect(N,1:n)
         colval = Array{N}(0) # unused
 
-        mesh.Pn[na] = MassMatrix(n, A, rowval, colptr, colval)
+        mesh.Pn[na] = MassMatrix(Int(n), A, rowval, colptr, colval)
 
     end
 

--- a/src/getNodalMassMatrix.jl
+++ b/src/getNodalMassMatrix.jl
@@ -121,6 +121,7 @@ function setupNodalMassMatrix(mesh, sigma)
 
     na = length(sigma)
     nc = mesh.nc
+    N  = typeof(nc)
 
     @assert na == nc "Invalid size of sigma"
 
@@ -128,12 +129,12 @@ function setupNodalMassMatrix(mesh, sigma)
 
         n = mesh.nn
         i, w = getNodalMassMatrixQuadrature(mesh)
-        j = repmat(1:nc, 8)
+        j = repmat(one(N):nc, 8)
         a = repmat(w, 8)
         A = sparse(i, j, a, n, na)
-        colptr = collect(1:n+1)
-        rowval = collect(1:n)
-        colval = Array{Int64}(0) # unused
+        colptr = collect(N,1:n+1)
+        rowval = collect(N,1:n)
+        colval = Array{N}(0) # unused
 
         mesh.Pn[na] = MassMatrix(n, A, rowval, colptr, colval)
 

--- a/src/getNumberOfNeighbors.jl
+++ b/src/getNumberOfNeighbors.jl
@@ -6,13 +6,14 @@ function  getNumberOfNeighbors(S::SparseArray3D)
 m1,m2,m3  = S.sz
 i,j,k,bsz = find3(S)
 
-ns = length(i)
-left  = zeros(Int64,ns)
-right = zeros(Int64,ns)
-upper = zeros(Int64,ns)
-lower = zeros(Int64,ns)
-front = zeros(Int64,ns)
-back  = zeros(Int64,ns)
+Tn2 = eltype(S.SV.nzind)
+ns  = length(i)
+left  = zeros(Tn2,ns)
+right = zeros(Tn2,ns)
+upper = zeros(Tn2,ns)
+lower = zeros(Tn2,ns)
+front = zeros(Tn2,ns)
+back  = zeros(Tn2,ns)
 
 ## UPPER ================================================
 Iin   = find((i-bsz).>=1)

--- a/src/getNumberOfNeighbors.jl
+++ b/src/getNumberOfNeighbors.jl
@@ -6,7 +6,9 @@ function  getNumberOfNeighbors(S::SparseArray3D)
 m1,m2,m3  = S.sz
 i,j,k,bsz = find3(S)
 
+
 Tn2 = eltype(S.SV.nzind)
+bsz = convert(Vector{Tn2},bsz)
 ns  = length(i)
 left  = zeros(Tn2,ns)
 right = zeros(Tn2,ns)
@@ -29,7 +31,7 @@ end
 
 ##   CHECK FOR 4 NEIGHBORS IF i-sz/2 >=1
 Iin   = find(((i-div.(bsz,2)) .>= 1) .& bsz.>1 )
-Itmp  = sub2ind(S.sz,i[Iin]-div.(bsz[Iin],2),j[Iin],k[Iin]);
+Itmp  = sub2ind(S.sz,i[Iin]-div.(bsz[Iin],Tn2(2)),j[Iin],k[Iin]);
 for kk = 1:length(Iin); if S.SV[Itmp[kk]] > 0; upper[Iin[kk]] = 4; end; end
 
 ## LOWER ==============================================
@@ -60,7 +62,7 @@ for kk = 1:length(Itmp)
 end
 ##   CHECK FOR 4 NEIGHBORS IF j-sz/2 >=1
 Iin   = find(((j-div.(bsz,2)) .>= 1) .&  bsz.>1 )
-Itmp  = sub2ind(S.sz,i[Iin],j[Iin]-div.(bsz[Iin],2),k[Iin])
+Itmp  = sub2ind(S.sz,i[Iin],j[Iin]-div.(bsz[Iin],Tn2(2)),k[Iin])
 for kk = 1:length(Itmp)
         if S.SV[Itmp[kk],1] > 0; left[Iin[kk]] = 4; end
 end
@@ -93,7 +95,7 @@ for kk = 1:length(Itmp)
 end
 ##   CHECK FOR 4 NEIGHBORS IF j-sz/2 >=1
 Iin   = find(((k-div.(bsz,2)) .>= 1)  .& bsz.>1 )
-Itmp  = sub2ind(S.sz,i[Iin],j[Iin],k[Iin]-div.(bsz[Iin],2))
+Itmp  = sub2ind(S.sz,i[Iin],j[Iin],k[Iin]-div.(bsz[Iin],Tn2(2)))
 front[Iin[find(S.SV[Itmp].>0)]] = 4
 
 ## Back ==========================================================

--- a/src/getSizeNumbering.jl
+++ b/src/getSizeNumbering.jl
@@ -292,7 +292,8 @@ function getNodalNumbering(S::SparseArray3D{Tn,Tn2}) where Tn <: Integer where T
     kk[7:8:ns8] = k + bsz
     kk[8:8:ns8] = k + bsz
 
-    N = sparse3(ii,jj,kk, Vector{Tn}(1:length(kk)), [m1+1,m2+1,m3+1])
+    N = sparse3(ii,jj,kk, convert(Vector{Tn},kk), [m1+1,m2+1,m3+1])
+    copy!(N.SV.nzval, one(Tn):Tn(nnz(N)) )
 
     return N
 end  # function getNodalNumbering

--- a/src/getSizeNumbering.jl
+++ b/src/getSizeNumbering.jl
@@ -41,17 +41,18 @@ function getEdgeNumbering(S::SparseArray3D)
 end
 
 
-function getEdgeSizeNumbering(S::SparseArray3D)
+function getEdgeSizeNumbering(S::SparseArray3D{Tn,Tn2}) where Tn <: Integer where Tn2 <: Integer
 
  m1,m2,m3 = S.sz
  i,j,k,bsz = find3(S)
 
  ns = nnz(S)
  ns4 = ns*4
- ii = Array{Int64}(ns4)
- jj = Array{Int64}(ns4)
- kk = Array{Int64}(ns4)
- vv = Array{Int64}(ns4)
+
+ ii = Array{Tn2}(ns4)
+ jj = Array{Tn2}(ns4)
+ kk = Array{Tn2}(ns4)
+ vv = Array{Tn}(ns4)
 
  vv[1:4:ns4] = bsz
  vv[2:4:ns4] = bsz
@@ -179,17 +180,17 @@ function getFaceNumbering(S::SparseArray3D)
 end
 
 
-function getFaceSizeNumbering(S::SparseArray3D)
+function getFaceSizeNumbering(S::SparseArray3D{Tn,Tn2}) where Tn <: Integer where Tn2 <: Integer
 
  m1,m2,m3 = S.sz
  i,j,k,bsz = find3(S)
 
  ns = nnz(S)
  ns2 = ns*2
- ii = Array{Int64}(ns2)
- jj = Array{Int64}(ns2)
- kk = Array{Int64}(ns2)
- vv = Array{Int64}(ns2)
+ ii = Array{Tn2}(ns2)
+ jj = Array{Tn2}(ns2)
+ kk = Array{Tn2}(ns2)
+ vv = Array{Tn}(ns2)
 
  vv[1:2:ns2] = bsz
  vv[2:2:ns2] = bsz
@@ -252,7 +253,7 @@ function getNodalNumbering(M::OcTreeMesh)
    return M.NN
 end
 
-function getNodalNumbering(S::SparseArray3D)
+function getNodalNumbering(S::SparseArray3D{Tn,Tn2}) where Tn <: Integer where Tn2 <: Integer
     # Numbering of the nodes of an OcTree structure
 
     m1,m2,m3 = S.sz
@@ -260,9 +261,9 @@ function getNodalNumbering(S::SparseArray3D)
 
     ns = nnz(S)
     ns8 = ns*8
-    ii = Array{Int64}(ns8)
-    jj = Array{Int64}(ns8)
-    kk = Array{Int64}(ns8)
+    ii = Array{Tn2}(ns8)
+    jj = Array{Tn2}(ns8)
+    kk = Array{Tn2}(ns8)
 
     ii[1:8:ns8] = i
     ii[2:8:ns8] = i + bsz
@@ -291,8 +292,7 @@ function getNodalNumbering(S::SparseArray3D)
     kk[7:8:ns8] = k + bsz
     kk[8:8:ns8] = k + bsz
 
-    N = sparse3(ii,jj,kk, kk, [m1+1,m2+1,m3+1])
-    copy!(N.SV.nzval, 1:nnz(N) )
+    N = sparse3(ii,jj,kk, Vector{Tn}(1:length(kk)), [m1+1,m2+1,m3+1])
 
     return N
 end  # function getNodalNumbering

--- a/src/getSizeNumbering.jl
+++ b/src/getSizeNumbering.jl
@@ -2,7 +2,7 @@
 export getEdgeSizeNumbering, getEdgeSize, getEdgeNumbering,
        getFaceSizeNumbering, getFaceSize, getFaceNumbering,
        getNodalNumbering, getCellNumbering, getVolume, getLength,
-       getVolumeVector
+       getVolumeVector, getLengthVector
 
 
 
@@ -141,6 +141,11 @@ function getLength(Mesh::OcTreeMesh)
         Mesh.L = spdiagm([l1;l2;l3])
     end
     return Mesh.L
+end
+
+function getLengthVector(Mesh::OcTreeMesh)
+    L = getLength(Mesh)
+    return L.nzval
 end
 
 #-------------------------------------------------------------------------

--- a/src/getSizeNumbering.jl
+++ b/src/getSizeNumbering.jl
@@ -76,7 +76,7 @@ function getEdgeSizeNumbering(S::SparseArray3D{Tn,Tn2}) where Tn <: Integer wher
  kk[3:4:ns4] = k + bsz
  kk[4:4:ns4] = k + bsz
 
- EX  = sparse3(ii,jj,kk, vv, collect(sizeEX))
+ EX  = sparse3(ii,jj,kk, vv, sizeEX)
  EXN = deepcopy(EX)
  copy!(EXN.SV.nzval, 1:nnz(EX) )
 
@@ -98,7 +98,7 @@ function getEdgeSizeNumbering(S::SparseArray3D{Tn,Tn2}) where Tn <: Integer wher
  kk[3:4:ns4] = k + bsz
  kk[4:4:ns4] = k + bsz
 
- EY  = sparse3(ii,jj,kk, vv, collect(sizeEY))
+ EY  = sparse3(ii,jj,kk, vv, sizeEY)
  EYN = deepcopy(EY)
  copy!(EYN.SV.nzval, 1:nnz(EY) )
 
@@ -120,7 +120,7 @@ function getEdgeSizeNumbering(S::SparseArray3D{Tn,Tn2}) where Tn <: Integer wher
  kk[3:4:ns4] = k
  kk[4:4:ns4] = k
 
- EZ  = sparse3(ii,jj,kk, vv, collect(sizeEZ))
+ EZ  = sparse3(ii,jj,kk, vv, sizeEZ)
  EZN = deepcopy(EZ)
  copy!(EZN.SV.nzval, 1:nnz(EZ) )
 
@@ -206,7 +206,7 @@ function getFaceSizeNumbering(S::SparseArray3D{Tn,Tn2}) where Tn <: Integer wher
  kk[1:2:ns2] = k
  kk[2:2:ns2] = k
 
- FX  = sparse3(ii,jj,kk, vv, collect(sizeFX))
+ FX  = sparse3(ii,jj,kk, vv, sizeFX)
  FXN = deepcopy(FX)
  copy!(FXN.SV.nzval, 1:nnz(FX) )
 
@@ -221,7 +221,7 @@ function getFaceSizeNumbering(S::SparseArray3D{Tn,Tn2}) where Tn <: Integer wher
  kk[1:2:ns2] = k
  kk[2:2:ns2] = k
 
- FY  = sparse3(ii,jj,kk, vv, collect(sizeFY))
+ FY  = sparse3(ii,jj,kk, vv, sizeFY)
  FYN = deepcopy(FY)
  copy!(FYN.SV.nzval, 1:nnz(FY) )
 
@@ -235,7 +235,7 @@ function getFaceSizeNumbering(S::SparseArray3D{Tn,Tn2}) where Tn <: Integer wher
  kk[1:2:ns2] = k
  kk[2:2:ns2] = k + bsz
 
- FZ  = sparse3(ii,jj,kk, vv, collect(sizeFZ))
+ FZ  = sparse3(ii,jj,kk, vv, sizeFZ)
  FZN = deepcopy(FZ)
  copy!(FZN.SV.nzval, 1:nnz(FZ) )
 
@@ -292,7 +292,7 @@ function getNodalNumbering(S::SparseArray3D{Tn,Tn2}) where Tn <: Integer where T
     kk[7:8:ns8] = k + bsz
     kk[8:8:ns8] = k + bsz
 
-    N = sparse3(ii,jj,kk, convert(Vector{Tn},kk), [m1+1,m2+1,m3+1])
+    N = sparse3(ii,jj,kk, convert(Vector{Tn},kk), (m1+1,m2+1,m3+1))
     copy!(N.SV.nzval, one(Tn):Tn(nnz(N)) )
 
     return N

--- a/src/refineOcTree.jl
+++ b/src/refineOcTree.jl
@@ -22,7 +22,7 @@ if !isempty(I)
     kk = vcat(k[I], k[I],        k[I],        k[I],        k[I]+bsz[I], k[I]+bsz[I], k[I]+bsz[I], k[I]+bsz[I], k[Ic])
     vv = vcat(bsz[I], bsz[I], bsz[I], bsz[I], bsz[I], bsz[I], bsz[I], bsz[I], bsz[Ic])
 
-    SF = sparse3(ii,jj,kk,vv,[m1,m2,m3])
+    SF = sparse3(ii,jj,kk,vv,(m1,m2,m3))
 else
     SF = S
 end

--- a/src/regularizeOcTree.jl
+++ b/src/regularizeOcTree.jl
@@ -25,8 +25,7 @@ function regularizeOcTree(S::SparseArray3D)
 
 
 # Regularize. This saves refinement iterations.
-S = regularizeOcTreeFaceNeighbours(S)
-
+S   = regularizeOcTreeFaceNeighbours(S)
 
 # Iterate until all cells meet the quality restrictions. Terminates in the
 # worst case when all cells are fine cells (bsz = 1).

--- a/src/regularizeOcTree.jl
+++ b/src/regularizeOcTree.jl
@@ -41,7 +41,7 @@ while true
    jj = vcat( j, j,     j+bsz, j+bsz, j,     j,     j+bsz, j+bsz )
    kk = vcat( k, k,     k,     k,     k+bsz, k+bsz, k+bsz, k+bsz )
 
-   sizeN = [m1+1, m2+1, m3+1 ]
+   sizeN = (m1+1, m2+1, m3+1)
    ijk = sub2ind( sizeN, ii,jj,kk )
    #[~,~,j] = unique(nind, 'rows')
    j = uniqueidx( ijk )[3]

--- a/src/sparse3.jl
+++ b/src/sparse3.jl
@@ -5,43 +5,36 @@ import Base.nonzeros
 import Base.nnz
 import Base.getindex
 import Base.setindex!
-import Base.ndims 
+import Base.ndims
 
-type SparseArray3D
-        SV::SparseVector{Int64}
-        sz::Vector{Int64}    # size of fine mesh
+struct SparseArray3D{N<:Integer,N2<:Integer}
+        SV::SparseVector{N,N2}
+        sz::Vector{N2}    # size of fine mesh
 end
 
 Base.size(S::SparseArray3D) = (S.sz[1], S.sz[2], S.sz[3])
-Base.size(S::SparseArray3D,dim::Int) = S.sz[dim]
+Base.size(S::SparseArray3D,dim::Integer) = S.sz[dim]
 Base.find(S::SparseArray3D) = find(S.SV)
 Base.ndims(S::SparseArray3D) = 3
 
-import Base.clear!
-function clear!(S::SparseArray3D)
-        S.SV = spzeros(Int,0)
-        S.sz = [0,0,0]
-        return
-end
-
-function sparse3(sz::Vector{Int})
-        S = spzeros(Int,prod(sz))
+function sparse3(sz::Vector)
+        S = spzeros(eltype(sz),eltype(sz),prod(sz))
         return SparseArray3D(S,sz)
 end
 
 import Base.isempty
 isempty(S::SparseArray3D) = (nnz(S.SV)==0)
 
-function sparse3(i::Vector{Int},j::Vector{Int},k::Vector{Int},v::Range,sz::Vector{Int})
+function sparse3(i::Vector,j::Vector,k::Vector,v::Range,sz::Vector)
         return sparse3(i,j,k,[v;],sz)
 end
-function sparse3(i::Vector{Int},j::Vector{Int},k::Vector{Int},v::Range,sz::Vector{Int},combine::Function)
+function sparse3(i::Vector,j::Vector,k::Vector,v::Range,sz::Vector,combine::Function)
         return sparse3(i,j,k,[v;],sz,combine)
 end
 
-function sparse3(i::Vector{Int},j::Vector{Int},k::Vector{Int},v::Vector{Int},sz::Vector{Int})
+function sparse3(i::Vector,j::Vector,k::Vector,v::Vector,sz::Vector)
 	IND = sub2ind(sz,i,j,k)
-   
+
   # Note that the following line would sort IND, and v would be permuted.  For
   # duplicate IND values, a SMALLEST v would be used.
   IND, v = sortpermFast(IND, v)
@@ -51,7 +44,7 @@ function sparse3(i::Vector{Int},j::Vector{Int},k::Vector{Int},v::Vector{Int},sz:
 end
 
 
-function sparse3(i::Vector{Int},j::Vector{Int},k::Vector{Int},v::Vector{Int},sz::Vector{Int},combine::Function)
+function sparse3(i::Vector,j::Vector,k::Vector,v::Vector,sz::Vector,combine::Function)
 
         IND = sub2ind(sz,i,j,k)
      	  S = sparsevec(IND,v, prod(sz), combine)
@@ -61,6 +54,10 @@ end
 function find3(S::SparseArray3D)
         IND = find(S.SV)
         i,j,k = ind2sub((S.sz[1],S.sz[2],S.sz[3]),IND)
+        # Tn = eltype(S.SV.nzval)
+        # i = convert(Vector{Tn},i)
+        # j = convert(Vector{Tn},j)
+        # k = convert(Vector{Tn},k)
         return i, j, k, nonzeros(S.SV)
 end
 
@@ -72,11 +69,12 @@ function nnz(S::SparseArray3D)
     return nnz(S.SV)
 end
 
-function getindex(S::SparseArray3D,i::Int,j::Int,k::Int)
+function getindex(S::SparseArray3D,i::Integer,j::Integer,k::Integer)
 	return S.SV[sub2ind(S.sz,i,j,k)]
 end
 
-function getindex(S::SparseArray3D,i::Vector{Int},j::Vector{Int},k::Vector{Int})
+function getindex(S::SparseArray3D,i::Vector{Integer},j::Vector{Integer},
+                  k::Vector{Integer})
 	sz = (length(i), length(j), length(k))
 	I,J,K = ndgrid(i,j,k)
 	si = sub2ind(S.sz,vec(I),vec(J),vec(K))
@@ -84,11 +82,13 @@ function getindex(S::SparseArray3D,i::Vector{Int},j::Vector{Int},k::Vector{Int})
 	return idx
 end
 
-function setindex!(S::SparseArray3D, v::Int, i::Int, j::Int, k::Int)
+function setindex!(S::SparseArray3D, v::Integer, i::Integer, j::Integer,
+                   k::Integer)
 	S.SV[sub2ind(S.sz,i,j,k)] = v
 end
 
-function setindex!(S::SparseArray3D, V::Vector{Int}, I::Vector{Int}, J::Vector{Int}, K::Vector{Int})
+function setindex!(S::SparseArray3D, V::Vector{Integer}, I::Vector{Integer},
+                   J::Vector{Integer}, K::Vector{Integer})
 	for ind=1:length(I)
 		S.SV[sub2ind(S.sz,I[ind],J[ind],K[ind])] = V[ind]
 	end

--- a/src/sparse3.jl
+++ b/src/sparse3.jl
@@ -6,6 +6,7 @@ import Base.nnz
 import Base.getindex
 import Base.setindex!
 import Base.ndims
+import Base.convert
 
 struct SparseArray3D{N<:Integer,N2<:Integer}
         SV::SparseVector{N,N2}
@@ -16,6 +17,14 @@ Base.size(S::SparseArray3D) = (S.sz[1], S.sz[2], S.sz[3])
 Base.size(S::SparseArray3D,dim::Integer) = S.sz[dim]
 Base.find(S::SparseArray3D) = find(S.SV)
 Base.ndims(S::SparseArray3D) = 3
+
+function convert(::Type{N}, ::Type{N2}, S::SparseArray3D) where N <: Integer where N2 <: Integer
+    return SparseArray3D(convert(SparseVector{N,N2}, S.SV), convert(Vector{N2}, S.sz))
+end
+
+function convert(::Type{N}, S::SparseArray3D) where N <: Integer
+    return convert(N, eltype(S.SV.nzind), S)
+end
 
 function sparse3(sz::Vector)
         S = spzeros(eltype(sz),eltype(sz),prod(sz))

--- a/src/sparse3.jl
+++ b/src/sparse3.jl
@@ -32,9 +32,14 @@ function convert(::Type{N}, S::SparseArray3D) where N <: Integer
     return convert(N, eltype(S.SV.nzind), S)
 end
 
-function sparse3(sz::Vector)
-        S = spzeros(eltype(sz),eltype(sz),prod(sz))
-        return SparseArray3D(S,sz)
+function sparse3(::Type{N}, sz::Tuple{N2,N2,N2}) where {N <: Integer, N2 <: Integer}
+    S = spzeros(N,N2,prod(sz))
+    return SparseArray3D(S,sz)
+end
+
+function sparse3(sz::Tuple{N2,N2,N2}) where N2 <: Integer
+  S = spzeros(N2,N2,prod(sz))
+  return SparseArray3D(S,sz)
 end
 
 import Base.isempty

--- a/src/sparse3.jl
+++ b/src/sparse3.jl
@@ -98,3 +98,11 @@ import Base.==
 function ==(S1::SparseArray3D,S2::SparseArray3D)
 	return (S1.SV==S2.SV) && (S1.sz == S2.sz)
 end
+
+import Base.clear!
+function clear!(S::SparseArray3D)
+    N  = eltype(S.SV.nzval)
+    N2 = eltype(S.SV.nzind)
+    sz = [size(S,1),size(S,2),size(S,3)]
+    return SparseArray3D(spzeros(N,N2,prod(sz)),sz)
+end

--- a/src/splitCells.jl
+++ b/src/splitCells.jl
@@ -14,7 +14,7 @@ end  # function splitCells
 
 #-----------------------------
 
-function splitCells( i,j,k,bsz, n, idx::Vector)
+function splitCells( i,j,k,bsz, n::Tuple, idx::Vector)
 # Split cells idx into 2*2*2=8 smaller cells.
 
 old_mesh_size = length(i)
@@ -61,7 +61,7 @@ for icel = 1:nidx
 
 end # icel
 
-S = sparse3(ii,jj,kk,vv,[n[1],n[2],n[3]])
+S = sparse3(ii,jj,kk,vv,n)
 
 return S
 end  # function splitCells

--- a/src/splitCells.jl
+++ b/src/splitCells.jl
@@ -21,17 +21,18 @@ old_mesh_size = length(i)
 nidx = length(idx)  # # of cells to split
 
 mesh_size = old_mesh_size + 7*nidx   # new mesh size
-
-ii = Array{Int}(mesh_size)
-jj = Array{Int}(mesh_size)
-kk = Array{Int}(mesh_size)
-vv = Array{Int}(mesh_size)
+Tn2 = eltype(i)
+Tn  = eltype(bsz)
+ii  = Array{Tn2}(mesh_size)
+jj  = Array{Tn2}(mesh_size)
+kk  = Array{Tn2}(mesh_size)
+vv  = Array{Tn}(mesh_size)
 
 ii[1:old_mesh_size] = i
 jj[1:old_mesh_size] = j
 kk[1:old_mesh_size] = k
 vv[1:old_mesh_size] = bsz
-	
+
 for icel = 1:nidx
 
    id = idx[icel]
@@ -44,7 +45,7 @@ for icel = 1:nidx
    vv[id] = bsz12  # original cell becomes smaller
 
    # Add 7 small cells
-   id1 = old_mesh_size + (icel-1)*7 + 1 
+   id1 = old_mesh_size + (icel-1)*7 + 1
    id2 = id1 + 7-1
 
    i1b = i1 + bsz12
@@ -55,12 +56,12 @@ for icel = 1:nidx
    jj[id1:id2] = vcat( j1,  j1b, j1b,  j1,  j1,  j1b, j1b )
    kk[id1:id1+2] = k1
    kk[id1+3:id2] = k1b
-  
+
    vv[id1:id2] = bsz12
 
-end # icel   
-	
+end # icel
+
 S = sparse3(ii,jj,kk,vv,[n[1],n[2],n[3]])
-	
+
 return S
 end  # function splitCells

--- a/src/uniteOcTrees.jl
+++ b/src/uniteOcTrees.jl
@@ -1,19 +1,19 @@
 export uniteOcTrees
 
 function uniteOcTrees(S1::SparseArray3D, S2::SparseArray3D)
-	
+
 	if size(S1) != size(S2)
 		error("Incompatible size")
 	end
 	SZ = S1.sz
-	
+
 	T1 = sparsevec(S1.SV.nzind, fill(1,length(S1.SV.nzval)), S1.SV.n)
 	T2 = sparsevec(S2.SV.nzind, fill(2,length(S2.SV.nzval)), S2.SV.n)
 	T  = T1+T2
-	
+
 	M = find(T)
 	V = T.nzval
-	
+
 	j1 = 1
 	j2 = 1
 	for k=1:length(M)
@@ -28,7 +28,7 @@ function uniteOcTrees(S1::SparseArray3D, S2::SparseArray3D)
 			V[k] = S1.SV.nzval[j1]
 			j1+=1
 		end
-	end	# 
+	end	#
 	I,J,K = ind2sub(size(S1), M)
 	S = sparse3(I,J,K,V,SZ)
 	return S
@@ -40,7 +40,7 @@ function uniteOcTrees(M1::OcTreeMeshFV, M2::OcTreeMeshFV)
     return MU
 end
 
-function uniteOcTrees(SL::Array{SparseArray3D,1})
+function uniteOcTrees(SL::Array{SparseArray3D{Tn,Tn2},1}) where {Tn <: Integer, Tn2 <: Integer}
   n = length(SL)
   if n > 2
     n1 = div(n,2)

--- a/test/randomOctreeMesh.jl
+++ b/test/randomOctreeMesh.jl
@@ -1,7 +1,8 @@
 
-function randomOctreeMesh( n::Vector, nrand )
+function randomOctreeMesh{Tn<:Integer,Tn2<:Integer}(::Type{Tn}, ::Type{Tn2},
+                             n::Tuple, nrand )
 # Create random octree mesh
-   S = initializeOctree(n)
+   S = initializeOctree(Tn,Tn2,n)
 
    ii = rand(1:n[1], nrand)
    jj = rand(1:n[2], nrand)
@@ -11,12 +12,11 @@ function randomOctreeMesh( n::Vector, nrand )
    S = regularizeOcTree(S)
 
 return S
-end  # function randomOctreeMesh   
+end  # function randomOctreeMesh
 
 
-function refineAtPoints( S::SparseArray3D,
-                        i1::Vector{Int64}, j1::Vector{Int64}, k1::Vector{Int64},
-                      cellsize::Int64 )
+function refineAtPoints( S::SparseArray3D,i1::Vector, j1::Vector, k1::Vector,
+                         cellsize::Integer )
 
 npts = length(i1)
 
@@ -57,8 +57,8 @@ while true
       jj = j[ic]
       kk = k[ic]
 
-      if ii+bb-1 < min_i || ii > max_i || 
-         jj+bb-1 < min_j || jj > max_j || 
+      if ii+bb-1 < min_i || ii > max_i ||
+         jj+bb-1 < min_j || jj > max_j ||
          kk+bb-1 < min_k || kk > max_k
         continue  # cell outside of region
       end
@@ -68,7 +68,7 @@ while true
 
          if ii+bb-1 >= i1[ipts] && ii <= i1[ipts] &&
             jj+bb-1 >= j1[ipts] && jj <= j1[ipts] &&
-            kk+bb-1 >= k1[ipts] && kk <= k1[ipts] 
+            kk+bb-1 >= k1[ipts] && kk <= k1[ipts]
 
             # large cell to split
             nsplit += 1
@@ -79,12 +79,12 @@ while true
       end  # ipts
 
    end  # ic
-   
 
-   if nsplit == 0 
+
+   if nsplit == 0
       break  # we are done
    end
-    
+
    S = splitCells(i,j,k,bsz, S.sz, splitcells[1:nsplit])
 
 end  # while

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,12 @@
 using JOcTree
 using Base.Test
 
-include("randomOctreeMesh.jl") 
-
+include("randomOctreeMesh.jl")
+intTypes = (Int32,Int64)
 @testset "JOcTree" begin
-include("testIO.jl")
-include("testMatrices.jl")
-include("testMassMatrices.jl")
-include("testMassMatrixDerivatives.jl")
-include("testInterpolationMatrix.jl")
+    include("testIO.jl")
+    include("testMatrices.jl")
+    include("testMassMatrices.jl")
+    include("testMassMatrixDerivatives.jl")
+    include("testInterpolationMatrix.jl")
 end

--- a/test/testIO.jl
+++ b/test/testIO.jl
@@ -4,17 +4,19 @@ println("Testing: exportUBCOcTreeMesh, importUBCOcTreeMesh, exportUBCOcTreeModel
 if hasHDF5
   println("Testing: exportHDF5OcTreeMesh, importHDF5OcTreeMesh")
 end
-
 @testset "IO" begin
+for Tn2 in intTypes
+for Tn in intTypes
+@testset "IO with intType1=$Tn, intType2=$Tn2" begin
 
-n = [128, 128, 128]
+n = (128, 128, 128)
 h = rand(1.:100.0,3)   # cell size
 x0 = rand(1.:100.0,3)
 
 nrand = 5
-S  = randomOctreeMesh(n, nrand)
-S2 = randomOctreeMesh(n, nrand)
-S3 = randomOctreeMesh(n, nrand)
+S  = randomOctreeMesh(Tn, Tn2, n, nrand)
+S2 = randomOctreeMesh(Tn, Tn2, n, nrand)
+S3 = randomOctreeMesh(Tn, Tn2, n, nrand)
 
 meshOut = getOcTreeMeshFV(S, h; x0=x0)
 
@@ -23,7 +25,7 @@ meshInUBC = importUBCOcTreeMesh("mesh.msh")
 @test meshInUBC==meshOut
 
 if hasHDF5
-  
+
   exportHDF5OcTreeMesh("meshHDF5.msh",meshOut)
   meshInHDF5 = importHDF5OcTreeMesh("meshHDF5.msh")
   @test meshInHDF5==meshOut
@@ -34,10 +36,10 @@ if hasHDF5
   m3 = getOcTreeMeshFV(S3, h; x0=x0)
   meshVec = [m1;m2;m3]
   meshDict = Dict([("m1",m1);("m2",m2);("m3",m3)])
-  
+
   exportHDF5OcTreeMesh("vecinHDF5.msh",meshVec)
   exportHDF5OcTreeMesh("dictinHDF5.msh",meshDict)
-  
+
   vecIn = importHDF5OcTreeMesh("vecinHDF5.msh")
   dictIn = importHDF5OcTreeMesh("dictinHDF5.msh")
   for (id,mesh) in zip(["1";"2";"3"],meshVec)
@@ -55,7 +57,7 @@ if hasHDF5
   for (id,mesh) in meshDict
     @test dictIn[id] == mesh
   end
-  
+
   for id = 1:3
     meshInHDF5 = importHDF5OcTreeMesh("vecinHDF5.msh",id)
     @test meshInHDF5 == meshVec[id]
@@ -64,9 +66,9 @@ if hasHDF5
     meshInHDF5 = importHDF5OcTreeMesh("dictinHDF5.msh",id)
     @test meshInHDF5 == meshDict[id]
   end
-  
-  @test_throws ErrorException importHDF5OcTreeMesh("dictinHDF5.msh",1)  
-  @test_throws ErrorException importHDF5OcTreeMesh("dictinHDF5.msh",[1,2,3])  
+
+  @test_throws ErrorException importHDF5OcTreeMesh("dictinHDF5.msh",1)
+  @test_throws ErrorException importHDF5OcTreeMesh("dictinHDF5.msh",[1,2,3])
 
 end
 
@@ -104,4 +106,7 @@ if hasHDF5
   rm("meshHDF5.msh")
 end
 
+end
+end
+end
 end

--- a/test/testInterpolationMatrix.jl
+++ b/test/testInterpolationMatrix.jl
@@ -1,19 +1,22 @@
 println("Testing: getInterpolationMatrix")
-
 @testset "Mesh interpolation" begin
+for Tn2 in intTypes
+for Tn in intTypes
+@testset "Mesh interpolation with intType1=$Tn, intType2=$Tn2" begin
 
 using jInv.Utils
 
 # Get random mesh
-n = [128 , 128 , 128]   # underlying mesh
-h = 1 ./ n   # cell size
+n = (128 , 128 , 128)   # underlying mesh
+h = 1 ./ collect(n)   # cell size
 x0 = [0. , 0. , 0.]
 
 nrand = 5
-S1 = randomOctreeMesh( n, nrand )
+S1 = randomOctreeMesh(Tn, Tn2, n, nrand )
 M1 = getOcTreeMeshFV(S1, h, x0=x0)
 
-S2 = createOcTreeFromBox(x0[1],x0[2],x0[3],n[1],n[2],n[3],h[1],h[2],h[3],0.5,0.5,0.5,0.5,0.5,0.5,2,2)
+S2 = createOcTreeFromBox(x0[1],x0[2],x0[3],n[1],n[2],n[3],h[1],h[2],h[3],
+                         0.5,0.5,0.5,0.5,0.5,0.5,2,2,1,Tn,Tn2)
 M2 = getOcTreeMeshFV(S2, h, x0=x0)
 
 P12 = getInterpolationMatrix(M1,M2)
@@ -33,4 +36,7 @@ PN21 = getInterpolationMatrix(M2,M1,N=N)
 @test P12 == PN12
 @test P21 == PN21
 
+end
+end
+end
 end

--- a/test/testMassMatrices.jl
+++ b/test/testMassMatrices.jl
@@ -1,15 +1,16 @@
 println("Testing: getNodalMassMatrix, getEdgeMassMatrix, getFaceMassMatrix")
-
-@testset "Mass matrices" begin
+for Tn2 in intTypes
+for Tn in intTypes
+@testset "Mass matrices with intType1=$Tn, intType2=$Tn2" begin
 
 # Get random mesh
-n = [256, 128, 64]
+n = (256, 128, 64)
 L = exp.(randn(3))
 h = L ./ n
 x0 = randn(3)
 xn = x0 + L
 nrand = 5 # local refinement at nrand random locations
-S = randomOctreeMesh(n, nrand)
+S = randomOctreeMesh(Tn, Tn2, n, nrand)
 mesh = getOcTreeMeshFV(S, h, x0=x0)
 
 ### Check exact integration of constant and linear coefficient
@@ -192,3 +193,5 @@ Mf6 = getFaceMassMatrix(mesh, c6)
 @test Mf3 ≈ Mf6
 
 end # end of testset
+end
+end

--- a/test/testMassMatrixDerivatives.jl
+++ b/test/testMassMatrixDerivatives.jl
@@ -1,18 +1,20 @@
 println("Testing: getdNodalMassMatrix, dNodalMassMatrixTimesVector, dNodalMassMatrixTrTimesVector,")
 println("         getdEdgeMassMatrix, dEdgeMassMatrixTimesVector, dEdgeMassMatrixTrTimesVector,")
 println("         getdFaceMassMatrix, dFaceMassMatrixTimesVector, dFaceMassMatrixTrTimesVector")
-
 @testset "Mass matrix derivatives" begin
+for Tn2 in intTypes
+for Tn in intTypes
+@testset "Mass matrix derivatives with intType1=$Tn, intType2=$Tn2" begin
 
 using jInv.Utils
 
 # Get random mesh
-n = [128 , 128 , 128]   # underlying mesh
-h = 1 ./ n   # cell size
+n = (128 , 128 , 128)   # underlying mesh
+h = 1 ./ collect(n)   # cell size
 x0 = [0. , 0. , 0.]
 
 nrand = 5
-S = randomOctreeMesh( n, nrand )
+S = randomOctreeMesh(Tn, Tn2, n, nrand )
 mesh = getOcTreeMeshFV(S, h, x0=x0)
 
 # Get random nodal, edge and face fields
@@ -114,3 +116,6 @@ for (u, du) in zip((freal, fcomplex), (dfreal, dfcomplex))
 end
 
 end # end of testset
+end
+end
+end

--- a/test/testMatrices.jl
+++ b/test/testMatrices.jl
@@ -1,4 +1,6 @@
-@testset "Matrices" begin
+for Tn2 in intTypes
+for Tn in intTypes
+@testset "Matrices with intType1=$Tn, intType2=$Tn2" begin
 using JOcTree
 using Base.Test
 
@@ -15,12 +17,12 @@ println("Testing: getNodalGradientMatrix, getCurlMatrix, getDivergenceMatrix")
 
 #-------------------------------------------
 
-n = [64, 64, 32]   # underlying mesh
-h = 1 ./ n   # cell size
+n = (64, 64, 32)   # underlying mesh
+h = 1 ./ collect(n)   # cell size
 x0 = [0. , 0. , 0.]
 
 nrand = 5
-S = randomOctreeMesh( n, nrand )
+S = randomOctreeMesh(Tn, Tn2, n, nrand )
 
 M = getOcTreeMeshFV(S, h, x0=x0)
 
@@ -64,7 +66,7 @@ ncells = Array{Int64}(ntests)
 
 for i = 1:ntests
    ncells[i] = nnz(S)
-   
+
 
    GRAD = getNodalGradientMatrix(M)
    xyz = getNodalGrid(M)
@@ -76,7 +78,7 @@ for i = 1:ntests
    dfx = getdFdX( EX[:,1], EX[:,2], EX[:,3] )
    dfy = getdFdY( EY[:,1], EY[:,2], EY[:,3] )
    dfz = getdFdZ( EZ[:,1], EZ[:,2], EZ[:,3] )
-   
+
    aGf = [ dfx; dfy; dfz ]
    difGRAD = Gf - aGf
    NdifGRAD[i] = norm(difGRAD, Inf)
@@ -88,7 +90,7 @@ for i = 1:ntests
    fx = getF( EX[:,1], EX[:,2], EX[:,3] )
    fy = getF( EY[:,1], EY[:,2], EY[:,3] )
    fz = getF( EZ[:,1], EZ[:,2], EZ[:,3] )
-   
+
    f = [fx ; fy ; fz]  # on faces
    Df = DIV * f   # Divergence on cell centres
 
@@ -109,7 +111,7 @@ for i = 1:ntests
    fx = getF( EX[:,1], EX[:,2], EX[:,3] )
    fy = getF( EY[:,1], EY[:,2], EY[:,3] )
    fz = getF( EZ[:,1], EZ[:,2], EZ[:,3] )
-   
+
    f = [fx ; fy ; fz]  # on edges
    Cf = CURL * f   # Curl on faces
 
@@ -128,8 +130,8 @@ for i = 1:ntests
 
 
    @printf("%8i  %.3e  %.3e  %.3e \n",
-               ncells[i], NdifGRAD[i], 
-                          NdifDIV[i],  
+               ncells[i], NdifGRAD[i],
+                          NdifDIV[i],
                           NdifCURL[i] )
 
    if i < ntests
@@ -155,4 +157,6 @@ end  # i
 # loglog( ncells, NdifGRAD, "r.-")
 # loglog( ncells, NdifDIV,  "g.-")
 # loglog( ncells, NdifCURL, "b.-")
+end
+end
 end


### PR DESCRIPTION
Do as the title says and also update most of the functions in the library to honour the parametrization. We now have `SparseArray3D{Tn,Tn2} where Tn<:Integer Tn2<:Integer` and
```
OcTreeMeshFV{Tf,Tn,Tn2} where Tf<:Number where Tn<:Integer where Tn2<:Integer
```
The integer arrays used for indexing sparse matrices must all have elements of type `Tn`, matching the `SparseArray3D` that is input to the mesh constructor. Main reason for this is to save memory by storing the sparse matrix integer arrays as `Vector{Int32}` instead of `Vector{Int64}`. All tests pass. Tested to work with MaxwellTime and MaxwellFrequency. Major caveat is that MUMPS.jl and Julia \ only work with Int64 sparse matrix indexing so using the Int32 storage limits you to Pardiso unless you convert matrices before passing them to other direct solvers. MUMPS.jl can easily be updated to accommodate the Int32s. 